### PR TITLE
Moving backend libraries from requirements to extra

### DIFF
--- a/.github/workflows/build_and_tests.yml
+++ b/.github/workflows/build_and_tests.yml
@@ -20,7 +20,9 @@ jobs:
     - name: Speculos dependencies
       run: sudo apt-get update && sudo apt-get install -y qemu-user-static
     - name: Build & install
-      run: pip install --extra-index-url https://test.pypi.org/simple/ -U .[tests]
+      run: |
+        pip install --extra-index-url https://test.pypi.org/simple/ -U .[tests,all_backends]
+        pip install -U click>=8
     - name: Gather boilerplate NanoS to run tests against
       uses: dawidd6/action-download-artifact@v2
       with:

--- a/README.md
+++ b/README.md
@@ -30,14 +30,25 @@ Ragger is currently not available on PIP repositories.
 To install it, you need to run at the root of the `git` repository:
 
 ```
-pip install --extra-index-url https://test.pypi.org/simple/ .
+pip install --extra-index-url https://test.pypi.org/simple/ .[all_backends]
 ```
 
 The extra index is important, as it brings the latest version of Speculos.
 
-### Other
+### Extras
 
-Speculos dependencies are obviously needed too.
+Sometimes we just need some function embedded in the library, or just one backend. It can be
+bothersome (and heavy) to import all dependencies when just one or none are needed.
+
+This is why backends are stored as extra in `ragger`. Installing `ragger` without extra means **it
+comes without any backends**.
+
+Extra are straightforward: `[speculos]`, `[ledgercomm]` and `[ledgerwallet]`. In the previous
+section, `[all_backends]` was used: it is a shortcut to `[speculos,ledgercomm,ledgerwallet]`.
+
+### Speculos dependencies
+
+If the Speculos extra is installed (to use the `SpeculosBackend`), system dependencies are needed.
 [Check the doc](https://speculos.ledger.com/installation/build.html) for these.
 
 ## Examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,6 @@
 [build-system]
 requires = [
-    "speculos>=0.1.128",
-    "ledgercomm",
-    "ledgercomm[hid]",
-    "ledgerwallet==0.1.3",
     "setuptools>=42",
-    "bip_utils>=2.4.0",
-    "py-sr25519-bindings==0.1.4",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,10 +23,6 @@ packages = find:
 include_package_data = True
 python_requires = >=3.6
 install_requires=
-        speculos>=0.1.128
-        ledgercomm
-        ledgercomm[hid]
-        ledgerwallet==0.1.3
         bip_utils>=2.4.0
         py-sr25519-bindings==0.1.4
 
@@ -47,3 +43,15 @@ checkers=
 doc=
         sphinx
         python-docs-theme
+speculos=
+        speculos>=0.1.128
+ledgercomm=
+        ledgercomm
+        ledgercomm[hid]
+ledgerwallet=
+        ledgerwallet==0.1.3
+all_backends=
+        speculos>=0.1.128
+        ledgercomm
+        ledgercomm[hid]
+        ledgerwallet==0.1.3

--- a/src/ragger/backend/__init__.py
+++ b/src/ragger/backend/__init__.py
@@ -14,9 +14,38 @@
    limitations under the License.
 """
 from .interface import BackendInterface, RaisePolicy
-from .speculos import SpeculosBackend
-from .ledgercomm import LedgerCommBackend
-from .ledgerwallet import LedgerWalletBackend
+
+
+ERROR_MSG = "This backend needs {}. Please install this package (run `pip install " \
+    "--extra-index-url https://test.pypi.org/simple/ ragger[{}]` or check this address: '{}')"
+
+try:
+    from .speculos import SpeculosBackend
+except ImportError:
+
+    def SpeculosBackend(*args, **kwargs):  # type: ignore
+        raise ImportError(
+            ERROR_MSG.format("Speculos", "speculos", "https://github.com/LedgerHQ/speculos/"))
+
+
+try:
+    from .ledgercomm import LedgerCommBackend
+except ImportError:
+
+    def LedgerCommBackend(*args, **kwargs):  # type: ignore
+        raise ImportError(
+            ERROR_MSG.format("LedgerComm", "ledgercomm", "https://github.com/LedgerHQ/ledgercomm/"))
+
+
+try:
+    from .ledgerwallet import LedgerWalletBackend
+except ImportError:
+
+    def LedgerWalletBackend(*args, **kwargs):  # type: ignore
+        raise ImportError(
+            ERROR_MSG.format("LedgerWallet", "ledgerwallet",
+                             "https://github.com/LedgerHQ/ledgerctl/"))
+
 
 __all__ = [
     "SpeculosBackend", "LedgerCommBackend", "LedgerWalletBackend", "BackendInterface", "RaisePolicy"


### PR DESCRIPTION
Backend libraries are no longer in require dependencies, but in extra, and should be explicitely installed with the extra syntax.

This way installing `ragger` can be fast and not take that much space. This could be useful when only several, one, or no backend is needed.

The extra alias `[all_backends]` is a shortcut to install the libraries for all the currently supported backends (Speculos, LedgerComm and LedgerWallet)