### PR TITLE
[fix] Update install command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Ragger is currently not available on PIP repositories.
 To install it, you need to run at the root of the `git` repository:
 
 ```
-pip install --extra-index-url https://test.pypi.org/simple/ .[all_backends]
+pip install --extra-index-url https://test.pypi.org/simple/ '.[all_backends]'
 ```
 
 The extra index is important, as it brings the latest version of Speculos.


### PR DESCRIPTION
The existing command line triggered this issue on my system: https://stackoverflow.com/questions/68855742/zsh-no-matches-found-uvicornstandard 
This commits fixes the command accordingly