### PR TITLE
backend: Sanitize screen and snapshot comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ The `src/ragger/backend/interface.py` file describes the methods that can be imp
 * `left_click`: perform a left click on a device.
 * `both_click`: perform a click on both buttons (left + right) of a device.
 * `compare_screen_with_snapshot`: compare the current device screen with the provided snapshot.
-* `save_screen_snapshot`: save the current device screen as a snapshot.
 
 The `src/ragger/navigator/navigator.py` file describes the methods that can be implemented by the different device navigators and that allow to interact with an emulated device:
 * `navigate`: navigate on the device according to a set of navigation instructions provided.

--- a/src/ragger/backend/interface.py
+++ b/src/ragger/backend/interface.py
@@ -289,27 +289,25 @@ class BackendInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def compare_screen_with_snapshot(self, snap_path: Path, crop: Optional[Crop] = None) -> bool:
+    def compare_screen_with_snapshot(self,
+                                     golden_snap_path: Path,
+                                     crop: Optional[Crop] = None,
+                                     tmp_snap_path: Optional[Path] = None,
+                                     golden_run: bool = False) -> bool:
         """
         Compare the current device screen with the provided snapshot.
 
-        :param snap_path: The path to the snap to compare the screen device with
-        :type snap_path: Path
+        :param golden_snap_path: The path to the snap to compare the screen
+                                 device with
+        :type golden_snap_path: Path
         :param crop: Optional crop options to use for the comparison
         :type crop: Crop
-
-        :return: True if matches else False
-        :rtype: bool
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def save_screen_snapshot(self, snap_path: Path):
-        """
-        Save the current device screen as a snapshot.
-
-        :param snap_path: The path where to save the screen snapshot
-        :type snap_path: Path
+        :param tmp_snap_path: Optional path where to store the screen snap used
+                              for the comparison
+        :type tmp_snap_path: Path
+        :param golden_run: Optional option to save the current screen as golden
+                           instead of comparing it.
+        :type golden_run: bool
 
         :return: True if matches else False
         :rtype: bool

--- a/src/ragger/backend/ledgercomm.py
+++ b/src/ragger/backend/ledgercomm.py
@@ -104,8 +104,9 @@ class LedgerCommBackend(BackendInterface):
     def both_click(self) -> None:
         pass
 
-    def compare_screen_with_snapshot(self, snap_path: Path, crop: Optional[Crop] = None) -> bool:
+    def compare_screen_with_snapshot(self,
+                                     golden_snap_path: Path,
+                                     crop: Optional[Crop] = None,
+                                     tmp_snap_path: Optional[Path] = None,
+                                     golden_run: bool = False) -> bool:
         return True
-
-    def save_screen_snapshot(self, path: Path) -> None:
-        pass

--- a/src/ragger/backend/ledgerwallet.py
+++ b/src/ragger/backend/ledgerwallet.py
@@ -102,8 +102,9 @@ class LedgerWalletBackend(BackendInterface):
     def both_click(self) -> None:
         pass
 
-    def compare_screen_with_snapshot(self, snap_path: Path, crop: Optional[Crop] = None) -> bool:
+    def compare_screen_with_snapshot(self,
+                                     golden_snap_path: Path,
+                                     crop: Optional[Crop] = None,
+                                     tmp_snap_path: Optional[Path] = None,
+                                     golden_run: bool = False) -> bool:
         return True
-
-    def save_screen_snapshot(self, path: Path) -> None:
-        pass


### PR DESCRIPTION
Before this commit, there was 3 screenshot taken over Speculos when comparing screen with golden_run:
- one for temp folder saving
- one for golden folder saving
- one for comparison with golden folder

Which could leads in hard to understand issues if the screen changes between one of theses events.

Therefore, this commit introduce a patch which allow to take only one screenshot and uses it for:
- temp folder saving
- golden folder saving if golden_run
- screen comparison with golden snap

all of this with keeping somehow the same API which is "compatible" with ledgercomm and ledgerwallet as it can be implemented as:
```
def compare_screen_with_snapshot(self,
                                 golden_snap_path: Path,
                                 crop: Optional[Crop] = None,
                                 tmp_snap_path: Optional[Path] = None,
                                 golden_run: bool = False) -> bool:

    # Ignore tmp_snap_path which is not possible on this backend

    if golden_run:
        return True

    # TODO:
    # Ask the user to compare the screen with the golden_snap_path
    # while taking into account the optional crop parameter
    return True
```

Fixes #51