### PR TITLE
Minor navigator tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - firmware: `Firmware:have_bagl` and `Firmware:have_nbgl` properties indicates which graphical
             interface the firmware implements.
 - navigator: Add USE_CASE_ADDRESS_CONFIRMATION_TAP
+- navigator: `add_callback()` method to register callbacks after Navigator initialization
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - navigator: Add USE_CASE_ADDRESS_CONFIRMATION_TAP
 - navigator: `add_callback()` method to register callbacks after Navigator initialization
 
+### Changed
+
+- navigator: `NavIns` arguments of `navigate()` and higher-level methods can now also be `NavInsID`,
+             which will automatically be converted to `NavIns` (with no argument for the callback)
+
 ### Fixed
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Fatstacks UseCaseHomeExt
+- Fatstacks `UseCaseHomeExt`
 - navigator: Improve navigation by waiting screen changes instead of hardcoded sleeps
-- navigator: navigate_and_compare(): Add optional snap_start_idx parameter
-- navigator: navigate_until_text(): take a list of validation instructions and check last screen
+- navigator: `navigate_and_compare()`: add optional snap_start_idx parameter
+- navigator: `navigate_until_text()`: take a list of validation instructions and check last screen
 
 
 ## [1.0.0] - 2022-12-26

--- a/src/ragger/error.py
+++ b/src/ragger/error.py
@@ -35,4 +35,4 @@ class ExceptionRAPDU(Exception):
     data: bytes = bytes()
 
     def __str__(self):
-        return f"Error [0x{self.status:x}] {self.data}"
+        return f"Error [0x{self.status:x}] {str(self.data)}"

--- a/src/ragger/firmware/fatstacks/layouts.py
+++ b/src/ragger/firmware/fatstacks/layouts.py
@@ -87,17 +87,17 @@ class FullKeyboardLetters(_FullKeyboard):
         self.client.finger_touch(*self.positions["change_case"])
 
 
-class FullKeyboardSpecialCharacters(_FullKeyboard):
+class _FullKeyboardSpecialCharacters(_FullKeyboard):
 
     def more_specials(self):
         self.client.finger_touch(*self.positions["more_specials"])
 
 
-class FullKeyboardSpecialCharacters1(FullKeyboardSpecialCharacters):
+class FullKeyboardSpecialCharacters1(_FullKeyboardSpecialCharacters):
     pass
 
 
-class FullKeyboardSpecialCharacters2(FullKeyboardSpecialCharacters):
+class FullKeyboardSpecialCharacters2(_FullKeyboardSpecialCharacters):
     pass
 
 

--- a/src/ragger/navigator/fatstacks_navigator.py
+++ b/src/ragger/navigator/fatstacks_navigator.py
@@ -14,6 +14,7 @@
    limitations under the License.
 """
 from time import sleep
+from typing import Callable, Dict
 
 from ragger.backend import BackendInterface
 from ragger.firmware import Firmware
@@ -25,7 +26,7 @@ class FatstacksNavigator(Navigator):
 
     def __init__(self, backend: BackendInterface, firmware: Firmware, golden_run: bool = False):
         screen = FullScreen(backend, firmware)
-        callbacks = {
+        callbacks: Dict[NavInsID, Callable] = {
             NavInsID.WAIT: sleep,
             NavInsID.TOUCH: backend.finger_touch,
             # possible headers

--- a/src/ragger/navigator/nano_navigator.py
+++ b/src/ragger/navigator/nano_navigator.py
@@ -14,6 +14,7 @@
    limitations under the License.
 """
 from time import sleep
+from typing import Callable, Dict
 
 from ragger.backend import BackendInterface
 from ragger.firmware import Firmware
@@ -23,7 +24,7 @@ from .navigator import NavInsID, Navigator
 class NanoNavigator(Navigator):
 
     def __init__(self, backend: BackendInterface, firmware: Firmware, golden_run: bool = False):
-        callbacks = {
+        callbacks: Dict[NavInsID, Callable] = {
             NavInsID.WAIT: sleep,
             NavInsID.RIGHT_CLICK: backend.right_click,
             NavInsID.LEFT_CLICK: backend.left_click,

--- a/src/ragger/navigator/navigator.py
+++ b/src/ragger/navigator/navigator.py
@@ -17,7 +17,7 @@ from abc import ABC
 from enum import auto, Enum
 from pathlib import Path
 from time import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from ragger.backend import BackendInterface, SpeculosBackend
 from ragger.firmware import Firmware
@@ -97,7 +97,7 @@ class Navigator(ABC):
     def __init__(self,
                  backend: BackendInterface,
                  firmware: Firmware,
-                 callbacks: Dict[NavInsID, Any],
+                 callbacks: Dict[NavInsID, Callable],
                  golden_run: bool = False):
         """Initializes the Backend
 

--- a/src/ragger/navigator/navigator.py
+++ b/src/ragger/navigator/navigator.py
@@ -164,6 +164,29 @@ class Navigator(ABC):
             golden, tmp_snap_path=tmp,
             golden_run=self._golden_run), f"Screen does not match golden {tmp}."
 
+    def add_callback(self, ins_id: NavInsID, callback: Callable, override: bool = True) -> None:
+        """
+        Register a new callback.
+
+        :param ins_id: The navigation instruction ID which will trigger the callback
+        :type ins_id: NavInsID
+        :param callback: The callback to call
+        :type callback: Callable
+        :param override: Replace an existing callback if the navigation instruction ID already
+                         exists. Defaults to `True`
+        :type override: bool
+
+        :raises KeyError: If the navigation instruction ID already exists and `override` is set to
+                          False
+
+        :return: None
+        :rtype: NoneType
+        """
+        if not override and ins_id in self._callbacks:
+            raise KeyError(f"Navigation instruction ID '{ins_id}' already exists in the "
+                           "registered callbacks")
+        self._callbacks[ins_id] = callback
+
     def navigate(self, instructions: List[NavIns]):
         """
         Navigate on the device according to a set of navigation instructions provided.

--- a/src/ragger/navigator/navigator.py
+++ b/src/ragger/navigator/navigator.py
@@ -187,12 +187,14 @@ class Navigator(ABC):
                            "registered callbacks")
         self._callbacks[ins_id] = callback
 
-    def navigate(self, instructions: List[NavIns]):
+    def navigate(self, instructions: List[Union[NavIns, NavInsID]]):
         """
         Navigate on the device according to a set of navigation instructions provided.
 
-        :param instructions: Set of navigation instructions.
-        :type instructions: List[NavIns]
+        :param instructions: Set of navigation instructions. Navigation instruction IDs are also
+                             accepted, and will be converted into navigation instruction (without
+                             any argument)
+        :type instructions: List[Union[NavIns, NavInsID]]
 
         :raises NotImplementedError: If the navigation instruction is not implemented.
 
@@ -200,6 +202,8 @@ class Navigator(ABC):
         :rtype: NoneType
         """
         for instruction in instructions:
+            if isinstance(instruction, NavInsID):
+                instruction = NavIns(instruction)
             if instruction.id not in self._callbacks:
                 raise NotImplementedError()
             self._callbacks[instruction.id](*instruction.args, **instruction.kwargs)
@@ -207,7 +211,7 @@ class Navigator(ABC):
     def navigate_and_compare(self,
                              path: Optional[Path],
                              test_case_name: Optional[Path],
-                             instructions: List[NavIns],
+                             instructions: List[Union[Union[NavIns, NavInsID]]],
                              timeout: float = 10.0,
                              screen_change_before_first_instruction: bool = True,
                              screen_change_after_last_instruction: bool = True,
@@ -220,11 +224,14 @@ class Navigator(ABC):
         :type path: Optional[Path]
         :param test_case_name: Relative path to the test case snapshots directory (from path).
         :type test_case_name: Optional[Path]
-        :param instructions: List of navigation instructions.
-        :type instructions: List[NavIns]
+        :param instructions: Set of navigation instructions. Navigation instruction IDs are also
+                             accepted.
+        :type instructions: List[Union[NavIns, NavInsID]]
         :param timeout: Timeout for each navigation step.
         :type timeout: int
-        :param screen_change_before_first_instruction: Wait for a screen change before first instruction.
+        :param screen_change_before_first_instruction: Wait for a screen change before first
+                                                       instruction, like a confirmation screen
+                                                       triggered through APDUs.
         :type screen_change_before_first_instruction: bool
         :param screen_change_after_last_instruction: Wait for a screen change after last instruction.
         :type screen_change_after_last_instruction: bool
@@ -264,8 +271,8 @@ class Navigator(ABC):
                                    len(instructions) + snap_start_idx)
 
     def navigate_until_snap(self,
-                            navigate_instruction: NavIns,
-                            validation_instruction: NavIns,
+                            navigate_instruction: Union[NavIns, NavInsID],
+                            validation_instruction: Union[NavIns, NavInsID],
                             path: Path,
                             test_case_name: Path,
                             start_img_name: str,
@@ -285,9 +292,11 @@ class Navigator(ABC):
         action is performed on the device.
 
         :param navigate_instruction: Navigation instruction to be performed until last snapshot is found.
-        :type navigate_instruction: NavIns
+                                     Navigation instruction ID is also accepted.
+        :type navigate_instruction: Union[NavIns, NavInsID]
         :param validation_instruction: Navigation instruction to be performed once last snapshot is found.
-        :type validation_instruction: NavIns
+                                       Navigation instruction ID is also accepted.
+        :type validation_instruction: Union[NavIns, NavInsID]
         :param path: Absolute path to the snapshots directory.
         :type path: Path
         :param test_case_name: Relative path to the test case snapshots directory (from path).
@@ -375,8 +384,8 @@ class Navigator(ABC):
         return img_idx
 
     def navigate_until_text_and_compare(self,
-                                        navigate_instruction: NavIns,
-                                        validation_instructions: List[NavIns],
+                                        navigate_instruction: Union[NavIns, NavInsID],
+                                        validation_instructions: List[Union[NavIns, NavInsID]],
                                         text: str,
                                         path: Optional[Path] = None,
                                         test_case_name: Optional[Path] = None,
@@ -399,9 +408,11 @@ class Navigator(ABC):
         :param test_case_name: Relative path to the test case snapshots directory (from path).
         :type test_case_name: Path
         :param navigate_instruction: Navigation instruction to be performed until the text is found.
-        :type navigate_instruction: NavIns
+                                     Navigation instruction ID is also accepted.
+        :type navigate_instruction: Union[NavIns, NavInsID]
         :param validation_instructions: Navigation instructions to be performed once the text is found.
-        :type validation_instructions: List[NavIns]
+                                        Navigation instruction IDs are also accepted.
+        :type validation_instructions: List[Union[NavIns, NavInsID]]
         :param text: Text string to look for.
         :type text: str
         :param timeout: Timeout for the whole navigation loop.
@@ -466,8 +477,8 @@ class Navigator(ABC):
                 snap_start_idx=idx)
 
     def navigate_until_text(self,
-                            navigate_instruction: NavIns,
-                            validation_instructions: List[NavIns],
+                            navigate_instruction: Union[NavIns, NavInsID],
+                            validation_instructions: List[Union[NavIns, NavInsID]],
                             text: str,
                             timeout: int = 30,
                             screen_change_before_first_instruction: bool = True,
@@ -483,9 +494,11 @@ class Navigator(ABC):
         action is performed on the device.
 
         :param navigate_instruction: Navigation instruction to be performed until the text is found.
-        :type navigate_instruction: NavIns
+                                     Navigation instruction ID is also accepted.
+        :type navigate_instruction: Union[NavIns, NavInsID]
         :param validation_instructions: Navigation instructions to be performed once the text is found.
-        :type validation_instructions: List[NavIns]
+                                        Navigation instruction IDs are also accepted.
+        :type validation_instructions: List[Union[NavIns, NavInsID]]
         :param text: Text string to look for.
         :type text: str
         :param timeout: Timeout for the whole navigation loop.

--- a/tests/unit/navigator/test_navigator.py
+++ b/tests/unit/navigator/test_navigator.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from ragger.backend import SpeculosBackend
 from ragger.firmware import Firmware
-from ragger.navigator import Navigator, NavIns
+from ragger.navigator import Navigator, NavIns, NavInsID
 
 
 class TestNavigator(TestCase):
@@ -118,14 +118,16 @@ class TestNavigator(TestCase):
         with self.assertRaises(NotImplementedError):
             self.navigator.navigate([NavIns(2)])
 
-    def test_navigate_ok_raises(self):
-        cb1, cb2 = MagicMock(), MagicMock()
-        ni1, ni2 = NavIns(1, (1, ), {'1': 1}), NavIns(2, (2, ), {'2': 2})
-        self.navigator._callbacks = {ni1.id: cb1, ni2.id: cb2}
-        self.navigator.navigate([ni1, ni2])
+    def test_navigate_ok(self):
+        cb1, cb2, cb3 = MagicMock(), MagicMock(), MagicMock()
+        ni1, ni2, ni3 = NavIns(1, (1, ), {'1': 1}), NavIns(2, (2, ), {'2': 2}), NavInsID.WAIT
+        self.navigator._callbacks = {ni1.id: cb1, ni2.id: cb2, ni3: cb3}
+        self.navigator.navigate([ni1, ni2, ni3])
         for cb, ni in [(cb1, ni1), (cb2, ni2)]:
             self.assertEqual(cb.call_count, 1)
             self.assertEqual(cb.call_args, (ni.args, ni.kwargs))
+        self.assertEqual(cb3.call_count, 1)
+        self.assertEqual(cb3.call_args, ((), ))
 
     def test_navigate_and_compare_ok(self):
         cb1, cb2 = MagicMock(), MagicMock()

--- a/tests/unit/navigator/test_navigator.py
+++ b/tests/unit/navigator/test_navigator.py
@@ -135,7 +135,10 @@ class TestNavigator(TestCase):
         self.navigator._callbacks = {ni1.id: cb1, ni2.id: cb2}
         self.navigator._backend = MagicMock(spec=SpeculosBackend)
         self.navigator._compare_snap = MagicMock()
-        self.navigator.navigate_and_compare(self.pathdir, self.pathdir, [ni1, ni2])
+        self.navigator.navigate_and_compare(self.pathdir,
+                                            self.pathdir, [ni1, ni2],
+                                            screen_change_before_first_instruction=True,
+                                            screen_change_after_last_instruction=True)
 
         # backend wait_for_screen_change function called 3 times
         self.assertEqual(self.navigator._backend.wait_for_screen_change.call_count, 3)


### PR DESCRIPTION
- adding a `Navigator:add_callback` method (allows to use a predefined Navigator such as `FatstacksNavigator` with adding/replacing some callbacks with custom ones)
- allowing `Navigator` methods to use `NavInsID` as well as `NavIns` as instruction: lots of callbacks are called without arguments (especially when using `UseCase*`), so it makes sense to call these methods with `[NavInsID.A, NavInsID.B, NavIns(NavInsID.C, (4, ))]` instead of `[NavIns(NavInsID.A), NavIns(NavInsID.B), NavIns(NavInsID.C, (4, ))]`
- `Navigator:navigate_and_compare` method: `screen_change_before_first_instruction` and `screen_change_after_last_instruction` set to `False` by default: default behavior of the method is to execute the given instructions, whatever the context. On the other way around, no instruction is executed, and the method raises a `TimeoutError`, which is an unclear behavior.