### PR TITLE
[fix] Classes using MetaScreen can declare their own __init__ 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- firmware/stax: Classes using `MetaScreen` can now declare their own `__init__` without it being overridden
+
 ## [1.3.1] - 2023-01-24
 
 ### Added
@@ -21,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- backend/speculos : improved reliability of wait_for_screen_change 
+- backend/speculos : improved reliability of wait_for_screen_change
 - firmware/stax : the "Suggestions" positions are shifted by Y+75px in order to fit with BOLOS
                   suggestion buttons, which are under the typing text area, not above.
 - navigator: Don't clean already existing snapshots when running `navigate_and_compare()` through `navigate_until_text_and_compare()`.

--- a/src/ragger/firmware/stax/screen.py
+++ b/src/ragger/firmware/stax/screen.py
@@ -86,12 +86,14 @@ class MetaScreen(type):
             key.split(USE_CASE_PREFIX)[1]: namespace.pop(key)
             for key in list(namespace.keys()) if key.startswith(USE_CASE_PREFIX)
         }
+        original_init = namespace.pop("__init__", lambda *args, **kwargs: None)
 
-        def init(self, client: BackendInterface, firmware: Firmware):
+        def init(self, client: BackendInterface, firmware: Firmware, *args, **kwargs):
             for attribute, cls in layouts.items():
                 setattr(self, attribute, cls(client, firmware))
             for attribute, cls in use_cases.items():
                 setattr(self, attribute, cls(client, firmware))
+            original_init(self, client, firmware, *args, **kwargs)
 
         namespace["__init__"] = init
         return super().__new__(cls, name, parents, namespace)

--- a/tests/unit/firmware/stax/test_screen_MetaScreen.py
+++ b/tests/unit/firmware/stax/test_screen_MetaScreen.py
@@ -12,12 +12,19 @@ class TestMetaScreen(TestCase):
         class Test(metaclass=MetaScreen):
             layout_one = self.layout
 
+            def __init__(self, client, firmware, some_argument, other=None):
+                self.some = some_argument
+                self.other = other
+
         self.cls = Test
         self.assertEqual(self.layout.call_count, 0)
 
     def test___init__(self):
         client, firmware = MagicMock(), MagicMock()
-        test = self.cls(client, firmware)
+        args = (client, firmware, "some")
+        test = self.cls(*args)
         self.assertEqual(self.layout.call_count, 1)
         self.assertEqual(self.layout.call_args, ((client, firmware), ))
         self.assertEqual(test.one, self.layout())
+        self.assertEqual(test.some, args[-1])
+        self.assertIsNone(test.other)


### PR DESCRIPTION
Previously, as the metaclass redefines the `__init__` of the subclass, classes defining their own `__init__` would have it overridden, which would trigger unclear error at runtime.

I thought the metaclass only applied on base class and construction such as:
```
class Mother(metaclass=MetaScreeen):
    use_case_whatever = UseCaseWhatever

class Child(Mother):
    def __init__(self, backend, firmware, all, the, argument=in, the=world):
        pass
```
... would do, but no, as a class builder, the metaclass is triggered everytime a class is defined with it on its ancestor.

The new code does not only override the existent `__init__`, but stores it then calls it at the end of the new `__init__`. This should take care of argument issue as well as inheritance with `super().__init__` calls.