### PR TITLE
Add custom seed option for speculos backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - navigator: Add USE_CASE_STATUS_DISMISS, this allows to dismiss the status instead of waiting for its end with USE_CASE_STATUS_WAIT.
+- conftest: add configuration and pytest options that allow a custom seed to be used for speculos.
 
 ### Changed
 - Dependency: Use speculos>=0.1.224 to avoid issues when running in slow setup.

--- a/src/ragger/conftest/configuration.py
+++ b/src/ragger/conftest/configuration.py
@@ -6,6 +6,7 @@ class OptionalOptions:
     SIDELOADED_APPS: dict
     SIDELOADED_APPS_DIR: str
     BACKEND_SCOPE: str
+    CUSTOM_SEED: str
 
 
 OPTIONAL = OptionalOptions(
@@ -25,4 +26,9 @@ OPTIONAL = OptionalOptions(
     # When using "session" all your tests will share a single backend instance (faster)
     # When using "function" each test will have its independent backend instance (no collusion)
     BACKEND_SCOPE="class",
+
+    # Use this parameter if you want speculos to use a custom seed instead of the default one.
+    # This would result in speculos being launched with --seed <CUSTOM_SEED>
+    # If a seed is provided through the "--seed" pytest command line option, it will override this one.
+    CUSTOM_SEED=str(),
 )

--- a/template/usage.md
+++ b/template/usage.md
@@ -70,5 +70,6 @@ Custom pytest options
     --display                   on Speculos, enables the display of the app screen using QT
     --golden_run                on Speculos, screen comparison functions will save the current screen instead of comparing
     --log_apdu_file <filepath>  log all apdu exchanges to the file in parameter. The previous file content is erased
-``` 
+    --seed                      on Speculos, use the seed (mnemonic) provided.
+```
 


### PR DESCRIPTION
Add a custom seed option in `configuration.py` to allow the user to use whichever seed he wants with speculos, not only the default one.