### PR TITLE
Fixes Alpine builds

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ include_package_data = True
 python_requires = >=3.6
 install_requires=
         bip_utils>=2.4.0
-        py-sr25519-bindings==0.1.4
+        py-sr25519-bindings>=0.2.0,<0.3.0
         semver>=2.13.0
 
 [options.packages.find]


### PR DESCRIPTION
Updates the version of the `py-sr25519-bindings` dependency which was causing Rust building issues on Alpine.