### PR TITLE
Change deployment trigger from commit message to tag

### DIFF
--- a/.github/workflows/build_and_tests.yml
+++ b/.github/workflows/build_and_tests.yml
@@ -1,14 +1,11 @@
-name: Build, test and deploy Ragger
+name: Build and test Ragger
 
 on:
   workflow_dispatch:
   push:
     branches:
       - master
-      - main
       - develop
-    tags:
-      - '*'
   pull_request:
 
 jobs:
@@ -53,91 +50,3 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         name: codecov-ragger
-
-  package_and_deploy:
-    name: Build and deploy Ragger Python Package
-    # needs: [build_install_test]
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Clone
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: Build Ragger Python package
-      run: |
-        pip install --upgrade pip build twine
-        PIP_EXTRA_INDEX_URL=https://test.pypi.org/simple/ python -m build
-        python -m twine check dist/*
-
-    - name: Get tag version
-      if: success() && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
-      id: tag
-      run: |
-        echo "TAG_VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
-        echo "Tag version: '${{ env.TAG_VERSION }}'"
-
-    - name: Check version against CHANGELOG
-      if: success() && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
-      run: |
-        CHANGELOG_VERSION=$(grep -Po '(?<=## \[)(\d\.)+[^\]]' CHANGELOG.md | head -n 1)
-        if [ "${{ env.TAG_VERSION }}" == "${CHANGELOG_VERSION}" ]; \
-        then \
-            exit 0; \
-        else \
-            echo "Tag '${{ env.TAG_VERSION }}' and CHANGELOG '${CHANGELOG_VERSION}' versions mismatch!"; \
-            exit 1; \
-        fi
-
-    - name: Get current branch
-      if: success() && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
-      id: branch
-      run: |
-        echo "BRANCH_NAME=$(git branch -r --contains ${{ github.ref }})" >> "$GITHUB_ENV"
-        echo "Current branch: ${{ env.BRANCH_NAME }}"
-
-    - name: Display current status
-      if: success() && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
-      run: |
-        echo "Current status is:"
-        echo "- Tag version: '${{ env.TAG_VERSION }}'"
-        echo "- Current branch: '${{ env.CURRENT_BRANCH }}'"
-
-    - name: Publish Python package on test.pypi.org
-      if: |
-        success() &&
-        github.event_name == 'push' &&
-        startsWith(github.event.ref, 'refs/tags/') &&
-        env.BRANCH_NAME == 'origin/develop'
-      run: python -m twine upload --repository testpypi dist/*
-      env:
-        TWINE_USERNAME: __token__
-        # TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PUBLIC_API_TOKEN  }}
-        TWINE_NON_INTERACTIVE: 1
-
-    - name: Publish Python package on pypi.org
-      if: |
-        success() &&
-        github.event_name == 'push' &&
-        startsWith(github.event.ref, 'refs/tags/') &&
-        env.BRANCH_NAME == 'origin/master'
-      run: python -m twine upload dist/*
-      env:
-        TWINE_USERNAME: __token__
-        # TWINE_PASSWORD: ${{ secrets.PYPI_PUBLIC_API_TOKEN  }}
-        TWINE_NON_INTERACTIVE: 1
-
-    - name: Publish a release on the repo
-      if: |
-        success() &&
-        github.event_name == 'push' &&
-        contains(fromJSON('["origin/develop", "origin/master"]'), env.BRANCH_NAME)
-      uses: "marvinpinto/action-automatic-releases@latest"
-      with:
-        automatic_release_tag: "v${{ env.TAG_VERSION }}"
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        prerelease: true
-        files: |
-          LICENSE
-          dist/

--- a/.github/workflows/build_and_tests.yml
+++ b/.github/workflows/build_and_tests.yml
@@ -7,6 +7,8 @@ on:
       - master
       - main
       - develop
+    tags:
+      - '*'
   pull_request:
 
 jobs:
@@ -54,7 +56,7 @@ jobs:
 
   package_and_deploy:
     name: Build and deploy Ragger Python Package
-    needs: [build_install_test]
+    # needs: [build_install_test]
     runs-on: ubuntu-latest
     steps:
 
@@ -63,39 +65,77 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Get Ragger version
-      id: version
-      run: |
-        echo "##[set-output name=version;]$(cat src/ragger/__init__.py  | grep __version__ | cut -d ' ' -f 3 | sed s/\"//g)";
-        echo "Version registered: ${{ steps.version.outputs.version }}"
-
-    - name: Build Ragger python package
+    - name: Build Ragger Python package
       run: |
         pip install --upgrade pip build twine
         PIP_EXTRA_INDEX_URL=https://test.pypi.org/simple/ python -m build
         python -m twine check dist/*
 
+    - name: Get tag version
+      if: success() && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+      id: tag
+      run: |
+        echo "TAG_VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
+        echo "Tag version: '${{ env.TAG_VERSION }}'"
+
+    - name: Check version against CHANGELOG
+      if: success() && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+      run: |
+        CHANGELOG_VERSION=$(grep -Po '(?<=## \[)(\d\.)+[^\]]' CHANGELOG.md | head -n 1)
+        if [ "${{ env.TAG_VERSION }}" == "${CHANGELOG_VERSION}" ]; \
+        then \
+            exit 0; \
+        else \
+            echo "Tag '${{ env.TAG_VERSION }}' and CHANGELOG '${CHANGELOG_VERSION}' versions mismatch!"; \
+            exit 1; \
+        fi
+
+    - name: Get current branch
+      if: success() && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+      id: branch
+      run: |
+        echo "BRANCH_NAME=$(git branch -r --contains ${{ github.ref }})" >> "$GITHUB_ENV"
+        echo "Current branch: ${{ env.BRANCH_NAME }}"
+
+    - name: Display current status
+      if: success() && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+      run: |
+        echo "Current status is:"
+        echo "- Tag version: '${{ env.TAG_VERSION }}'"
+        echo "- Current branch: '${{ env.CURRENT_BRANCH }}'"
+
     - name: Publish Python package on test.pypi.org
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/develop' && contains(github.event.head_commit.message, 'release')
+      if: |
+        success() &&
+        github.event_name == 'push' &&
+        startsWith(github.event.ref, 'refs/tags/') &&
+        env.BRANCH_NAME == 'origin/develop'
       run: python -m twine upload --repository testpypi dist/*
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PUBLIC_API_TOKEN  }}
+        # TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PUBLIC_API_TOKEN  }}
         TWINE_NON_INTERACTIVE: 1
 
     - name: Publish Python package on pypi.org
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, 'release')
+      if: |
+        success() &&
+        github.event_name == 'push' &&
+        startsWith(github.event.ref, 'refs/tags/') &&
+        env.BRANCH_NAME == 'origin/master'
       run: python -m twine upload dist/*
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_PUBLIC_API_TOKEN  }}
+        # TWINE_PASSWORD: ${{ secrets.PYPI_PUBLIC_API_TOKEN  }}
         TWINE_NON_INTERACTIVE: 1
 
     - name: Publish a release on the repo
-      if: success() && github.event_name == 'push' && contains(fromJSON('["refs/heads/develop", "refs/heads/master"]'), github.ref) && contains(github.event.head_commit.message, 'release')
+      if: |
+        success() &&
+        github.event_name == 'push' &&
+        contains(fromJSON('["origin/develop", "origin/master"]'), env.BRANCH_NAME)
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
-        automatic_release_tag: "v${{ steps.version.outputs.version }}"
+        automatic_release_tag: "v${{ env.TAG_VERSION }}"
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         prerelease: true
         files: |

--- a/.github/workflows/build_and_tests.yml
+++ b/.github/workflows/build_and_tests.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Clone
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Speculos dependencies
       run: sudo apt-get update && sudo apt-get install -y qemu-user-static tesseract-ocr libtesseract-dev

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,19 +33,17 @@ jobs:
       id: tag
       run: |
         echo "TAG_VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
-        echo "Tag version: '${{ env.TAG_VERSION }}'"
 
-    - name: Get current branch
-      id: branch
+    - name: Get destination repository
+      id: destination
       run: |
-        echo "BRANCH_NAME=$(git branch -r --contains ${{ github.ref }})" >> "$GITHUB_ENV"
-        echo "Current branch: ${{ env.BRANCH_NAME }}"
+        echo "DESTINATION=$(python tools/info_extractor.py --destination ${GITHUB_REF#refs/*/})" >> "$GITHUB_ENV"
 
     - name: Display current status
       run: |
         echo "Current status is:"
         echo "- Tag version: '${{ env.TAG_VERSION }}'"
-        echo "- Current branch: '${{ env.CURRENT_BRANCH }}'"
+        echo "- Pypi repository destination: '${{ env.DESTINATION }}'"
         echo "- Content of the ragger/__version__.py file:"
         cat src/ragger/__version__.py
 
@@ -62,7 +60,7 @@ jobs:
         fi
 
     - name: Publish Python package on test.pypi.org
-      if: startsWith(github.ref, 'refs/tags/') && env.BRANCH_NAME == 'origin/develop'
+      if: startsWith(github.ref, 'refs/tags/') && env.DESTINATION == 'test.pypi.org'
       run: python -m twine upload --repository testpypi dist/*
       env:
         TWINE_USERNAME: __token__
@@ -70,7 +68,7 @@ jobs:
         TWINE_NON_INTERACTIVE: 1
 
     - name: Publish Python package on pypi.org
-      if: startsWith(github.ref, 'refs/tags/') && env.BRANCH_NAME == 'origin/master'
+      if: startsWith(github.ref, 'refs/tags/') && env.DESTINATION == 'pypi.org'
       run: python -m twine upload dist/*
       env:
         TWINE_USERNAME: __token__
@@ -78,7 +76,7 @@ jobs:
         TWINE_NON_INTERACTIVE: 1
 
     - name: Publish a release on the repo
-      if: startsWith(github.ref, 'refs/tags/') && contains(fromJSON('["origin/develop", "origin/master"]'), env.BRANCH_NAME)
+      if: startsWith(github.ref, 'refs/tags/')
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         automatic_release_tag: "v${{ env.TAG_VERSION }}"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -50,13 +50,15 @@ jobs:
         echo "Current status is:"
         echo "- Tag version: '${{ env.TAG_VERSION }}'"
         echo "- Current branch: '${{ env.CURRENT_BRANCH }}'"
+        echo "- Content of the ragger/__version__.py file:"
+        cat src/ragger/__version__.py
 
     - name: Publish Python package on test.pypi.org
       if: env.BRANCH_NAME == 'origin/develop'
       run: python -m twine upload --repository testpypi dist/*
       env:
         TWINE_USERNAME: __token__
-        # TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PUBLIC_API_TOKEN  }}
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PUBLIC_API_TOKEN  }}
         TWINE_NON_INTERACTIVE: 1
 
     - name: Publish Python package on pypi.org
@@ -64,7 +66,7 @@ jobs:
       run: python -m twine upload dist/*
       env:
         TWINE_USERNAME: __token__
-        # TWINE_PASSWORD: ${{ secrets.PYPI_PUBLIC_API_TOKEN  }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PUBLIC_API_TOKEN  }}
         TWINE_NON_INTERACTIVE: 1
 
     - name: Publish a release on the repo

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,79 @@
+name: Deploy Ragger
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  package_and_deploy:
+    name: Build and deploy Ragger Python Package
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Clone
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Build Ragger Python package
+      run: |
+        pip install --upgrade pip build twine
+        PIP_EXTRA_INDEX_URL=https://test.pypi.org/simple/ python -m build
+        python -m twine check dist/*
+
+    - name: Get tag version
+      id: tag
+      run: |
+        echo "TAG_VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
+        echo "Tag version: '${{ env.TAG_VERSION }}'"
+
+    - name: Check version against CHANGELOG
+      run: |
+        CHANGELOG_VERSION=$(grep -Po '(?<=## \[)(\d\.)+[^\]]' CHANGELOG.md | head -n 1)
+        if [ "${{ env.TAG_VERSION }}" == "${CHANGELOG_VERSION}" ]; \
+        then \
+            exit 0; \
+        else \
+            echo "Tag '${{ env.TAG_VERSION }}' and CHANGELOG '${CHANGELOG_VERSION}' versions mismatch!"; \
+            exit 1; \
+        fi
+
+    - name: Get current branch
+      id: branch
+      run: |
+        echo "BRANCH_NAME=$(git branch -r --contains ${{ github.ref }})" >> "$GITHUB_ENV"
+        echo "Current branch: ${{ env.BRANCH_NAME }}"
+
+    - name: Display current status
+      run: |
+        echo "Current status is:"
+        echo "- Tag version: '${{ env.TAG_VERSION }}'"
+        echo "- Current branch: '${{ env.CURRENT_BRANCH }}'"
+
+    - name: Publish Python package on test.pypi.org
+      if: env.BRANCH_NAME == 'origin/develop'
+      run: python -m twine upload --repository testpypi dist/*
+      env:
+        TWINE_USERNAME: __token__
+        # TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PUBLIC_API_TOKEN  }}
+        TWINE_NON_INTERACTIVE: 1
+
+    - name: Publish Python package on pypi.org
+      if: env.BRANCH_NAME == 'origin/master'
+      run: python -m twine upload dist/*
+      env:
+        TWINE_USERNAME: __token__
+        # TWINE_PASSWORD: ${{ secrets.PYPI_PUBLIC_API_TOKEN  }}
+        TWINE_NON_INTERACTIVE: 1
+
+    - name: Publish a release on the repo
+      if: contains(fromJSON('["origin/develop", "origin/master"]'), env.BRANCH_NAME)
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        automatic_release_tag: "v${{ env.TAG_VERSION }}"
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        prerelease: true
+        files: |
+          LICENSE
+          dist/

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - '*'
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
 
 jobs:
   package_and_deploy:
@@ -28,17 +35,6 @@ jobs:
         echo "TAG_VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
         echo "Tag version: '${{ env.TAG_VERSION }}'"
 
-    - name: Check version against CHANGELOG
-      run: |
-        CHANGELOG_VERSION=$(grep -Po '(?<=## \[)(\d\.)+[^\]]' CHANGELOG.md | head -n 1)
-        if [ "${{ env.TAG_VERSION }}" == "${CHANGELOG_VERSION}" ]; \
-        then \
-            exit 0; \
-        else \
-            echo "Tag '${{ env.TAG_VERSION }}' and CHANGELOG '${CHANGELOG_VERSION}' versions mismatch!"; \
-            exit 1; \
-        fi
-
     - name: Get current branch
       id: branch
       run: |
@@ -53,8 +49,20 @@ jobs:
         echo "- Content of the ragger/__version__.py file:"
         cat src/ragger/__version__.py
 
+    - name: Check version against CHANGELOG
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        CHANGELOG_VERSION=$(grep -Po '(?<=## \[)(\d\.)+[^\]]' CHANGELOG.md | head -n 1)
+        if [ "${{ env.TAG_VERSION }}" == "${CHANGELOG_VERSION}" ]; \
+        then \
+            exit 0; \
+        else \
+            echo "Tag '${{ env.TAG_VERSION }}' and CHANGELOG '${CHANGELOG_VERSION}' versions mismatch!"; \
+            exit 1; \
+        fi
+
     - name: Publish Python package on test.pypi.org
-      if: env.BRANCH_NAME == 'origin/develop'
+      if: startsWith(github.ref, 'refs/tags/') && env.BRANCH_NAME == 'origin/develop'
       run: python -m twine upload --repository testpypi dist/*
       env:
         TWINE_USERNAME: __token__
@@ -62,7 +70,7 @@ jobs:
         TWINE_NON_INTERACTIVE: 1
 
     - name: Publish Python package on pypi.org
-      if: env.BRANCH_NAME == 'origin/master'
+      if: startsWith(github.ref, 'refs/tags/') && env.BRANCH_NAME == 'origin/master'
       run: python -m twine upload dist/*
       env:
         TWINE_USERNAME: __token__
@@ -70,7 +78,7 @@ jobs:
         TWINE_NON_INTERACTIVE: 1
 
     - name: Publish a release on the repo
-      if: contains(fromJSON('["origin/develop", "origin/master"]'), env.BRANCH_NAME)
+      if: startsWith(github.ref, 'refs/tags/') && contains(fromJSON('["origin/develop", "origin/master"]'), env.BRANCH_NAME)
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         automatic_release_tag: "v${{ env.TAG_VERSION }}"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Clone
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Install APT dependencies
         run: |
           sudo apt-get update

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 coverage.xml
 build/
 dist/
+__version__.py
 
 tests/elfs/
 snapshots-tmp/

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ If the Speculos extra is installed (to use the `SpeculosBackend`), system depend
 
 ## Features
 
-The `src/ragger/backend/interface.py` file describes the methods that can be implemented by the different backends and that allow to interact with a device (either a real device or emulated):
+The `src/ragger/backend/interface.py` file describes the methods that can be implemented by the
+different backends and that allow to interact with a device (either a real device or emulated):
 
 * `send`: send a formatted APDU.
 * `send_raw`: send a raw APDU.
@@ -75,12 +76,16 @@ The `src/ragger/backend/interface.py` file describes the methods that can be imp
 * `finger_touch`: performs a finger touch on the device screen.
 * `compare_screen_with_snapshot`: compare the current device screen with the provided snapshot.
 
-The `src/ragger/navigator/navigator.py` file describes the methods that can be implemented by the different device navigators and that allow to interact with an emulated device:
+The `src/ragger/navigator/navigator.py` file describes the methods that can be implemented by the
+different device navigators and that allow to interact with an emulated device:
 * `navigate`: navigate on the device according to a set of navigation instructions provided.
-* `navigate_and_compare`: navigate on the device according to a set of navigation instructions provided then compare each step screenshot with "golden images".
+* `navigate_and_compare`: navigate on the device according to a set of navigation instructions
+  provided then compare each step screenshot with "golden images".
 * `navigate_until_snap`: navigate on the device until a snapshot is found and then validate.
-* `navigate_until_text`: navigate on the device until a text string is found on screen and then validate.
-* `navigate_until_text_and_compare`: same as `navigate_until_text` but compare screenshots taken at each step with "golden images".
+* `navigate_until_text`: navigate on the device until a text string is found on screen and then
+  validate.
+* `navigate_until_text_and_compare`: same as `navigate_until_text` but compare screenshots taken at
+  each step with "golden images".
 
 ## Examples
 ### With `pytest`
@@ -166,3 +171,21 @@ Once done, you can generate the documentation:
 ```bash
 (cd doc && make gen_resources && make html)
 ```
+
+## Repository deployment, versions & tags
+
+Versions and changes are documented into the [CHANGELOG.md](CHANGELOG.MD) file.
+
+Pushing a tag on the central GitHub repository triggers a deployment. Python packages are deployed
+onto `pypi.org` or `test.pypi.org` depending on the tag, which must follow the following scheme:
+
+- if the tag starts with `test-v`, for instance `test-v2.9.23`, the package is deployed on
+  `test.pypi.org` with version `2.9.23`.
+- if the tag directly is composed of the `v` + the version, for instance `v2.9.23`, the package is
+  deployed on `pypi.org` with version `2.9.23`.
+
+The version substring itself must respect the basic form of semantic versioning, i.e `(\d\.){2}\d`.
+`-alpha`, `.dev22+ff35` or whatever other format will not be accepted, and the CI will fail.
+
+The version embedded into the tag must also fit with the latest version documented into the
+[CHANGELOG.md](CHANGELOG.MD) file. If not, the CI will fail.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,9 +54,9 @@ import sys
 
 sys.path.insert(0, os.path.abspath('../src/'))
 
-from ragger import __version__
-version = __version__
-release = __version__
+from importlib.metadata import version as get_version
+release = get_version('ragger')
+version = '.'.join(release.split('.')[:2])
 
 ## Autodoc conf ##
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,13 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=45",
+    "setuptools_scm[toml]>=6.2",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/ragger/__version__.py"
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/ragger/__version__.py"
+tag_regex = "((?P<destination>test)-)?v(?P<version>(\\d\\.){2}\\d)"
+fallback_version = "0.0.0"
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = ragger
-version = attr: ragger.__version__
 author = Ledger
 author_email = hello@ledger.fr
 description = Testing framework using Speculos and LedgerComm as backends

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,8 @@ project_urls =
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX :: Linux
     Operating System :: MacOS :: MacOS X

--- a/src/ragger/__init__.py
+++ b/src/ragger/__init__.py
@@ -13,7 +13,10 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-__version__ = "1.7.3"
+try:
+    from __version__ import __version__  # noqa
+except ImportError:
+    __version__ = "unknown version"  # noqa
 
 from ragger.logger import init_loggers
 

--- a/tools/info_extractor.py
+++ b/tools/info_extractor.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser, Namespace
+from re import compile
+
+
+REGEX = r"((?P<destination>test)-)?v(?P<version>(\d\.){2}\d)"
+
+
+def parse_args() -> Namespace:
+    description = """
+Extracts version and other info from a string
+
+Implemented to extract destination / version number from a tag.
+
+Tags can be like:
+
+- 1.2.3 -> simple tag, means the package is to be deployed on `pypi.org` with version 1.2.3
+- test-2.34.5 -> composite tag, means the package is to be deployed on `test.pypi.org` with version 2.34.5
+"""
+    parser = ArgumentParser(description=description)
+    parser.add_argument("string", type=str)
+    parser.add_argument("--version", "-v", action='store_true', default=False, help="Extract the version from the string")
+    parser.add_argument("--destination", "-d", action='store_true', default=False, help="Deduce the destination from the string, either `pypi.org` or `test.pypi.org`")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        results = compile(REGEX).match(args.string).groupdict()
+    except AttributeError as e:
+        raise ValueError(f"String '{args.string}' did not match regex '{REGEX}'") from e
+
+    if results["destination"] is None:
+        results["destination"] = "pypi.org"
+    else:
+        results["destination"] = "test.pypi.org"
+
+    if args.version:
+        print(results["version"])
+    elif args.destination:
+        print(results["destination"])
+    else:
+        print(results)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Remarks:

- tags and version in the CHANGELOG must be equals. This is currently not the case, as tags are like `v1.7.3` while CHANGELOG has `1.7.3`
- previous behavior (the packaging is done - but not pushed - on push and PR, just to check if it works) is reproduced, with additional steps fetching version / branch info and displaying them