### PR TITLE
[fix] PyQt5 no longer necessary to use Ragger in headless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.8.1] - 2023-05-30
+
+### Fix
+- import: Feature developed in [this branch](https://github.com/LedgerHQ/ragger/pull/76) forced all
+          Ragger installation to have PyQt5 and its dependencies installed. This is no longer the
+          case.
+
 ## [1.8.0] - 2023-05-30
 
 ### Added

--- a/src/ragger/gui/__init__.py
+++ b/src/ragger/gui/__init__.py
@@ -13,6 +13,15 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-from .process import RaggerGUI
+try:
+    from .process import RaggerGUI
+except ImportError as e:
+    if e.name != "QtCore":
+        raise e
+
+    def RaggerGUI(*args, **kwatgs):  # type: ignore
+        raise ImportError(
+            "This feature needs PyQt5. Please install this package (run `pip install pyqt5`)")
+
 
 __all__ = ["RaggerGUI"]


### PR DESCRIPTION
"Lazy exception" on `RaggerGUI` class instantiation.

Like what is already implemented for the backends (which are all optional), this PR catches an import error in case `Qt` is not present on the system. It then defines the needed class `RaggerGUI` as a fonction which will trigger an error when called.

This exception will then only be triggered if a `ragger.backend.physical_backend.PhysicalBackend` is instantiated with `with_gui=True`.