### PR TITLE
speculos: Only pause ticker during navigation steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2023-06-22
+
+### Fixed
+- speculos: Only pause ticker during navigation steps
+
 ## [1.9.0] - 2023-06-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ different backends and that allow to interact with a device (either a real devic
 * `both_click`: perform a click on both buttons (left + right) of a device.
 * `finger_touch`: performs a finger touch on the device screen.
 * `compare_screen_with_snapshot`: compare the current device screen with the provided snapshot.
+* `pause_ticker`: pause the backend time.
+* `resume_ticker`: resume the backend time.
+* `send_tick`: request the backend to increase time by a single step.
 
 The `src/ragger/navigator/navigator.py` file describes the methods that can be implemented by the
 different device navigators and that allow to interact with an emulated device:

--- a/src/ragger/backend/interface.py
+++ b/src/ragger/backend/interface.py
@@ -494,3 +494,48 @@ class BackendInterface(ABC):
         :rtype: Any
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def pause_ticker(self) -> None:
+        """
+        Pause the backend time.
+
+        This method may be left void on backends connecting to physical devices,
+        where a physical interaction must be performed instead.
+        This will prevent the instrumentation to fail (the void method won't
+        raise `NotImplementedError`).
+
+        :return: None
+        :rtype: NoneType
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def resume_ticker(self) -> None:
+        """
+        Resume the backend time.
+
+        This method may be left void on backends connecting to physical devices,
+        where a physical interaction must be performed instead.
+        This will prevent the instrumentation to fail (the void method won't
+        raise `NotImplementedError`).
+
+        :return: None
+        :rtype: NoneType
+        """
+        pass
+
+    @abstractmethod
+    def send_tick(self) -> None:
+        """
+        Request the backend to increase time by a single step.
+
+        This method may be left void on backends connecting to physical devices,
+        where a physical interaction must be performed instead.
+        This will prevent the instrumentation to fail (the void method won't
+        raise `NotImplementedError`).
+
+        :return: None
+        :rtype: NoneType
+        """
+        pass

--- a/src/ragger/backend/physical_backend.py
+++ b/src/ragger/backend/physical_backend.py
@@ -117,3 +117,12 @@ class PhysicalBackend(BackendInterface):
 
     def get_current_screen_content(self) -> List:
         return list()
+
+    def pause_ticker(self) -> None:
+        pass
+
+    def resume_ticker(self) -> None:
+        pass
+
+    def send_tick(self) -> None:
+        pass

--- a/src/ragger/backend/stub.py
+++ b/src/ragger/backend/stub.py
@@ -81,3 +81,12 @@ class StubBackend(BackendInterface):
 
     def get_current_screen_content(self) -> Any:
         pass
+
+    def pause_ticker(self) -> None:
+        pass
+
+    def resume_ticker(self) -> None:
+        pass
+
+    def send_tick(self) -> None:
+        pass

--- a/src/ragger/navigator/navigator.py
+++ b/src/ragger/navigator/navigator.py
@@ -206,6 +206,8 @@ class Navigator(ABC):
         :rtype: NoneType
         """
 
+        self._backend.pause_ticker()
+
         # Navigation initialization: no-op instruction to:
         # - wait for screen change depending on screen_change_before_first_instruction.
         #   this is necessary:
@@ -242,6 +244,8 @@ class Navigator(ABC):
                                       timeout,
                                       wait_for_screen_change=False,
                                       snap_idx=snap_start_idx + idx + 1)
+
+        self._backend.resume_ticker()
 
     def navigate(self,
                  instructions: List[Union[NavIns, NavInsID]],
@@ -444,6 +448,8 @@ class Navigator(ABC):
             if timeout == 30:
                 timeout = 200
 
+        self._backend.pause_ticker()
+
         # Navigation initialization: no-op instruction to:
         # - wait for screen change depending on screen_change_before_first_instruction.
         #   this is necessary when an APDU was just sent and we want to make sure the
@@ -488,6 +494,8 @@ class Navigator(ABC):
                 screen_change_before_first_instruction=False,
                 screen_change_after_last_instruction=screen_change_after_last_instruction,
                 snap_start_idx=idx)
+
+        self._backend.resume_ticker()
 
     def navigate_until_text(self,
                             navigate_instruction: Union[NavIns, NavInsID],

--- a/tests/unit/backend/test_interface.py
+++ b/tests/unit/backend/test_interface.py
@@ -61,6 +61,15 @@ class DummyBackend(BackendInterface):
     def get_current_screen_content(self):
         return self.mock.get_current_screen_content()
 
+    def pause_ticker(self) -> None:
+        pass
+
+    def resume_ticker(self) -> None:
+        pass
+
+    def send_tick(self) -> None:
+        pass
+
 
 class TestBackendInterface(TestCase):
 


### PR DESCRIPTION
Always pausing time caused deadlock when apps call io_seproxyhal_io_heartbeat() before returning a response for an APDU and there is no UI flow in the process (hence no wait_for_screen_change that before this commit was the only way to give ticks to the app).