### PR TITLE
navigator: Restore NavInsID.USE_CASE_REVIEW_CONFIRM custom wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2] - 2023-06-23
+
+### Fixed
+- navigator: Restore `NavInsID.USE_CASE_REVIEW_CONFIRM` custom wait for screen change for cases where the app call `io_seproxyhal_io_heartbeat()` before next screen is displayed.
+
 ## [1.9.1] - 2023-06-22
 
 ### Fixed

--- a/src/ragger/navigator/navigator.py
+++ b/src/ragger/navigator/navigator.py
@@ -15,6 +15,7 @@
 """
 from abc import ABC
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from time import time
 from typing import Callable, Dict, List, Optional, Union
 
@@ -144,20 +145,52 @@ class Navigator(ABC):
         if instruction.id not in self._callbacks:
             raise NotImplementedError(f"No callback registered for instruction ID {instruction.id}")
 
-        # Call instruction callback
-        self._callbacks[instruction.id](*instruction.args, **instruction.kwargs)
+        if instruction.id == NavInsID.USE_CASE_REVIEW_CONFIRM:
+            # Specific handling due to the fact that the screen is updated multiple
+            # time with a progress bar during this instruction callback execution.
+            # Indeed, this progress bar implies a screen change with previous screen
+            # content known by the backend.
+            # Therefore simply calling wait_for_screen_change() here will result in
+            # race issues.
+            # That's why we are first backuping the screen content in a temp file.
+            # This screen content is then used to check if the screen changed enough,
+            # e.g. with cropping the progress bar from the screen.
+            with NamedTemporaryFile(suffix='.png') as tmp:
+                tmp_file = Path(tmp.name)
+                # Backup screen content before instruction in tmp file
+                self._backend.compare_screen_with_snapshot(tmp_file,
+                                                           tmp_snap_path=tmp_file,
+                                                           golden_run=True)
 
-        # Wait for screen change unless explicitly specify otherwise
-        if wait_for_screen_change:
-            if instruction.id in [
-                    NavInsID.WAIT_FOR_SCREEN_CHANGE, NavInsID.WAIT_FOR_HOME_SCREEN,
-                    NavInsID.WAIT_FOR_TEXT_ON_SCREEN, NavInsID.WAIT_FOR_TEXT_NOT_ON_SCREEN
-            ]:
-                # Function wait_for_screen_change() is already called during
-                # instruction callback execution above.
-                pass
-            else:
-                self._backend.wait_for_screen_change(timeout)
+                # Call instruction callback
+                self._callbacks[instruction.id](*instruction.args, **instruction.kwargs)
+
+                # Wait for screen change unless explicitly specify otherwise
+                if wait_for_screen_change:
+                    # Compare to previous backup file without considering the bottom
+                    # which holds the progress bar.
+                    cropping = Crop(lower=220)
+                    endtime = time() + timeout
+                    while True:
+                        self._backend.wait_for_screen_change(endtime - time())
+                        if not self._backend.compare_screen_with_snapshot(tmp_file, cropping):
+                            break
+
+        else:
+            # Call instruction callback
+            self._callbacks[instruction.id](*instruction.args, **instruction.kwargs)
+
+            # Wait for screen change unless explicitly specify otherwise
+            if wait_for_screen_change:
+                if instruction.id in [
+                        NavInsID.WAIT_FOR_SCREEN_CHANGE, NavInsID.WAIT_FOR_HOME_SCREEN,
+                        NavInsID.WAIT_FOR_TEXT_ON_SCREEN, NavInsID.WAIT_FOR_TEXT_NOT_ON_SCREEN
+                ]:
+                    # Function wait_for_screen_change() is already called during
+                    # instruction callback execution above.
+                    pass
+                else:
+                    self._backend.wait_for_screen_change(timeout)
 
         # Compare snap with golden reference
         if path and test_case_name:


### PR DESCRIPTION
This is necessary for cases where the app call
`io_seproxyhal_io_heartbeat()` before next screen is displayed. Note that in most situation such `io_seproxyhal_io_heartbeat()` are useless.