### PR TITLE
firmware/stax/use_cases.py: Increase confirm to 2.4sec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.2] - 2023-07-31
+
+### Changed:
+- firmware:use_case: Increase confirm time to 2.4 sec following SDK change
+
 ## [1.11.1] - 2023-07-19
 
 ### Fixed:

--- a/src/ragger/firmware/stax/use_cases.py
+++ b/src/ragger/firmware/stax/use_cases.py
@@ -109,8 +109,8 @@ class UseCaseReview(_UseCase):
         self.client.finger_touch(*self.positions["reject"])
 
     def confirm(self):
-        # SDK needs at least 1.5s for long press.
-        self.client.finger_touch(*self.positions["confirm"], 1.5)
+        # SDK needs at least 2.4s for long press.
+        self.client.finger_touch(*self.positions["confirm"], 2.4)
 
 
 class UseCaseViewDetails(_UseCase):


### PR DESCRIPTION
This is necessary to adapt for Hold to approve duration change in the SDK.
Linked to https://github.com/LedgerHQ/ledger-secure-sdk/commit/1118eb62ec905a5fc153a35d3049d26446aeffd5