### PR TITLE
Batch SpeculosBackend clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2024-01-19
+
+### Added
+- Batch generator with the `SpeculosBackend:batch` methods which allows to spawn several Speculos
+  client of the same app, with (if needed) different seed, RNG and/or attestation or user keys.
+
 ## [1.13.1] - 2023-12-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,12 +32,16 @@ More complete documentation can be found [here](https://ledgerhq.github.io/ragge
 
 ### Python package
 
-Ragger is currently not available on PIP repositories.
-
-To install it, you need to run at the root of the `git` repository:
+Ragger is available on https://pypi.org. To install it, just run:
 
 ```
-pip install --extra-index-url https://test.pypi.org/simple/ '.[all_backends]'
+pip install ragger[all_backends]
+```
+
+You can also install it from sources. At the root of the `git` repository, run:
+
+```
+pip install '.[all_backends]'
 ```
 
 The extra index is important, as it brings the latest version of Speculos.

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ doc=
         docutils==0.16  # higher versions trigger build bugs with the RTD theme
 speculos=
         speculos>=0.2.8
+        mnemonic
 ledgercomm=
         ledgercomm
         ledgercomm[hid]

--- a/src/ragger/backend/speculos.py
+++ b/src/ragger/backend/speculos.py
@@ -272,6 +272,17 @@ class SpeculosBackend(BackendInterface):
                 return
 
     @classmethod
+    def clean_args(cls: Type[T], speculos_args: List) -> None:
+        logger = get_default_logger()
+        for argument in [cls._ARGS_APDU_PORT_KEY, cls._ARGS_API_PORT_KEY]:
+            if argument in speculos_args:
+                logger.warning("'%s' argument is ignored on batch mode", argument)
+                index = speculos_args.index(argument)
+                # popipng argument and its value
+                speculos_args.pop(index)
+                speculos_args.pop(index)
+
+    @classmethod
     def batch(cls: Type[T],
               application: Path,
               firmware: Firmware,
@@ -304,19 +315,7 @@ class SpeculosBackend(BackendInterface):
                 additional_args.extend(["--attestation-key", urandom(32).hex()])
             if "args" in tmp_kwargs:
                 existing_args = tmp_kwargs.pop("args")
-                if cls._ARGS_APDU_PORT_KEY in existing_args:
-                    logger.warning("'%s' argument is ignored on batch mode",
-                                   cls._ARGS_APDU_PORT_KEY)
-                    index = existing_args.index(cls._ARGS_APDU_PORT_KEY)
-                    # popipng argument and its value
-                    existing_args.pop(index)
-                    existing_args.pop(index)
-                if cls._ARGS_API_PORT_KEY in existing_args:
-                    logger.warning("'%s' argument is ignored on batch mode", cls._ARGS_API_PORT_KEY)
-                    index = existing_args.index(cls._ARGS_API_PORT_KEY)
-                    # popping argument and its value
-                    existing_args.pop(index)
-                    existing_args.pop(index)
+                cls.clean_args(existing_args)
                 additional_args = existing_args + additional_args
             tmp_kwargs["args"] = additional_args
             logger.info("Args: %s", tmp_kwargs["args"])

--- a/src/ragger/backend/speculos.py
+++ b/src/ragger/backend/speculos.py
@@ -13,11 +13,15 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
+import socket
 from contextlib import contextmanager
+from copy import deepcopy
 from io import BytesIO
+from mnemonic import Mnemonic
+from os import urandom
 from pathlib import Path
 from PIL import Image
-from typing import Optional, Generator, List
+from typing import Optional, Generator, List, Type, TypeVar
 from time import time, sleep
 from re import match
 
@@ -26,8 +30,23 @@ from speculos.mcu.seproxyhal import TICKER_DELAY
 
 from ragger.error import ExceptionRAPDU
 from ragger.firmware import Firmware
+from ragger.logger import get_default_logger
 from ragger.utils import RAPDU, Crop
 from .interface import BackendInterface
+
+STARTING_RANGE = 7000
+T = TypeVar("T", bound="SpeculosBackend")
+
+
+def _is_port_in_use(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(('localhost', port)) == 0
+
+
+def _get_unused_port_from(starting_port: int) -> int:
+    while _is_port_in_use(starting_port):
+        starting_port += 1
+    return starting_port
 
 
 def raise_policy_enforcer(function):
@@ -250,3 +269,42 @@ class SpeculosBackend(BackendInterface):
             self.wait_for_screen_change(endtime - time())
             if screenshot_equal(self._last_screenshot, self._home_screenshot):
                 return
+
+    @classmethod
+    def batch(cls: Type[T],
+              application: Path,
+              firmware: Firmware,
+              number: int,
+              *args,
+              different_seeds: bool = True,
+              different_rng: bool = True,
+              different_private: bool = True,
+              different_attestation: bool = False,
+              **kwargs) -> List["SpeculosBackend"]:
+        logger = get_default_logger()
+        logger.info("Request to spawn %d Speculos instances of '%s'", number, application)
+        test_port = STARTING_RANGE
+        result: List["SpeculosBackend"] = list()
+        while len(result) < number:
+            tmp_kwargs = deepcopy(kwargs)
+            api_port = _get_unused_port_from(test_port)
+            apdu_port = _get_unused_port_from(api_port + 1)
+            logger.info("Instance %d ports: %d (API) and %s (APDU)",
+                        len(result) + 1, api_port, apdu_port)
+            test_port = apdu_port + 1
+            additional_args = [cls._ARGS_API_PORT_KEY, str(api_port), "--apdu-port", str(apdu_port)]
+            if different_seeds:
+                additional_args.extend(["--seed", Mnemonic("english").generate(strength=256)])
+            if different_rng:
+                additional_args.extend(["--deterministic-rng", f"{apdu_port}{api_port}"])
+            if different_private:
+                additional_args.extend(["--user-private-key", urandom(32).hex()])
+            if different_attestation:
+                additional_args.extend(["--attestation-key", urandom(32).hex()])
+            if "args" in tmp_kwargs:
+                tmp_kwargs["args"].extend(additional_args)
+            else:
+                tmp_kwargs["args"] = additional_args
+            logger.info("Args: %s", tmp_kwargs["args"])
+            result.append(cls(application, firmware, *args, **tmp_kwargs))
+        return result

--- a/src/ragger/backend/speculos.py
+++ b/src/ragger/backend/speculos.py
@@ -73,6 +73,7 @@ class SpeculosBackend(BackendInterface):
     _DEFAULT_API_PORT = 5000
     _ARGS_KEY = 'args'
     _ARGS_API_PORT_KEY = '--api-port'
+    _ARGS_APDU_PORT_KEY = '--apdu-port'
 
     def __init__(self,
                  application: Path,
@@ -302,9 +303,22 @@ class SpeculosBackend(BackendInterface):
             if different_attestation:
                 additional_args.extend(["--attestation-key", urandom(32).hex()])
             if "args" in tmp_kwargs:
-                tmp_kwargs["args"].extend(additional_args)
-            else:
-                tmp_kwargs["args"] = additional_args
+                existing_args = tmp_kwargs.pop("args")
+                if cls._ARGS_APDU_PORT_KEY in existing_args:
+                    logger.warning("'%s' argument is ignored on batch mode",
+                                   cls._ARGS_APDU_PORT_KEY)
+                    index = existing_args.index(cls._ARGS_APDU_PORT_KEY)
+                    # popipng argument and its value
+                    existing_args.pop(index)
+                    existing_args.pop(index)
+                if cls._ARGS_API_PORT_KEY in existing_args:
+                    logger.warning("'%s' argument is ignored on batch mode", cls._ARGS_API_PORT_KEY)
+                    index = existing_args.index(cls._ARGS_API_PORT_KEY)
+                    # popping argument and its value
+                    existing_args.pop(index)
+                    existing_args.pop(index)
+                additional_args = existing_args + additional_args
+            tmp_kwargs["args"] = additional_args
             logger.info("Args: %s", tmp_kwargs["args"])
             result.append(cls(application, firmware, *args, **tmp_kwargs))
         return result

--- a/tests/unit/backend/test_speculos.py
+++ b/tests/unit/backend/test_speculos.py
@@ -6,6 +6,8 @@ from typing import List
 from ragger.backend import SpeculosBackend
 from ragger.firmware import Firmware
 
+APPNAME = "some app"
+
 
 def get_next_in_list(the_list: List, elt: str) -> str:
     index = the_list.index(elt)
@@ -17,19 +19,19 @@ class TestSpeculosBackend(TestCase):
     maxDiff = None
 
     def test___init__ok(self):
-        SpeculosBackend("some app", Firmware.NANOS)
+        SpeculosBackend(APPNAME, Firmware.NANOS)
 
     def test___init__args_ok(self):
-        SpeculosBackend("some app", Firmware.NANOS, args=["some", "specific", "arguments"])
+        SpeculosBackend(APPNAME, Firmware.NANOS, args=["some", "specific", "arguments"])
 
     def test___init__args_nok(self):
         with self.assertRaises(AssertionError):
-            SpeculosBackend("some app", Firmware.NANOS, args="not a list")
+            SpeculosBackend(APPNAME, Firmware.NANOS, args="not a list")
 
     def test_context_manager(self):
         expected_image = b"1234"
-        with patch("ragger.backend.speculos.SpeculosClient") as patched_client:
-            backend = SpeculosBackend("some app", Firmware.NANOS)
+        with patch("ragger.backend.speculos.SpeculosClient"):
+            backend = SpeculosBackend(APPNAME, Firmware.NANOS)
         self.assertIsNone(backend._last_screenshot)
         self.assertIsNone(backend._home_screenshot)
         # patching SpeculosClient.get_screenshot
@@ -50,10 +52,9 @@ class TestSpeculosBackend(TestCase):
             client_number = 2
             arg_api_port = 1234
             arg_apdu_port = 4321
-            application = "some app"
 
             clients = SpeculosBackend.batch(
-                application,
+                APPNAME,
                 Firmware.NANOS,
                 client_number,
                 different_attestation=True,
@@ -73,7 +74,7 @@ class TestSpeculosBackend(TestCase):
             for index, client in enumerate(clients):
                 args, kwargs = all_client_args[index]
                 self.assertEqual(args, ())
-                self.assertEqual(kwargs["app"], application)
+                self.assertEqual(kwargs["app"], APPNAME)
                 self.assertEqual(kwargs["api_url"], f"http://127.0.0.1:{client._port}")
                 speculos_args = kwargs["args"]
                 client_seeds.add(get_next_in_list(speculos_args, "--seed"))

--- a/tests/unit/backend/test_speculos.py
+++ b/tests/unit/backend/test_speculos.py
@@ -1,17 +1,109 @@
+from io import BytesIO
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
+from typing import List
 
 from ragger.backend import SpeculosBackend
 from ragger.firmware import Firmware
 
 
+def get_next_in_list(the_list: List, elt: str) -> str:
+    index = the_list.index(elt)
+    return the_list[index + 1]
+
+
 class TestSpeculosBackend(TestCase):
 
+    maxDiff = None
+
     def test___init__ok(self):
-        SpeculosBackend("some app", firmware=Firmware.NANOS)
+        SpeculosBackend("some app", Firmware.NANOS)
 
     def test___init__args_ok(self):
-        SpeculosBackend("some app", firmware=Firmware.NANOS, args=["some", "specific", "arguments"])
+        SpeculosBackend("some app", Firmware.NANOS, args=["some", "specific", "arguments"])
 
     def test___init__args_nok(self):
         with self.assertRaises(AssertionError):
-            SpeculosBackend("some app", firmware=Firmware.NANOS, args="not a list")
+            SpeculosBackend("some app", Firmware.NANOS, args="not a list")
+
+    def test_context_manager(self):
+        expected_image = b"1234"
+        with patch("ragger.backend.speculos.SpeculosClient") as patched_client:
+            backend = SpeculosBackend("some app", Firmware.NANOS)
+        self.assertIsNone(backend._last_screenshot)
+        self.assertIsNone(backend._home_screenshot)
+        # patching SpeculosClient.get_screenshot
+        backend._client.get_screenshot.return_value = expected_image
+        # patching method so that __enter__ is not stuck for 20s
+        backend._retrieve_client_screen_content = lambda: {"events": True}
+        with backend as yielded:
+            self.assertTrue(backend._client.__enter__.called)
+            self.assertEqual(backend, yielded)
+            self.assertEqual(backend._last_screenshot, backend._home_screenshot)
+            self.assertEqual(backend._last_screenshot.getvalue(),
+                             BytesIO(expected_image).getvalue())
+            self.assertFalse(backend._client.__exit__.called)
+        self.assertTrue(backend._client.__exit__.called)
+
+    def test_batch_ok(self):
+        with patch("ragger.backend.speculos.SpeculosClient") as patched_client:
+            client_number = 2
+            arg_api_port = 1234
+            arg_apdu_port = 4321
+            application = "some app"
+
+            clients = SpeculosBackend.batch(
+                application,
+                Firmware.NANOS,
+                client_number,
+                different_attestation=True,
+                args=['--apdu-port', arg_apdu_port, '--api-port', arg_api_port])
+
+            self.assertEqual(len(clients), client_number)
+            self.assertEqual(patched_client.call_count, client_number)
+            all_client_args = patched_client.call_args_list
+
+            client_seeds = set()
+            client_rngs = set()
+            client_priv_keys = set()
+            client_attestations = set()
+            client_api_ports = set()
+            client_apdu_ports = set()
+
+            for index, client in enumerate(clients):
+                args, kwargs = all_client_args[index]
+                self.assertEqual(args, ())
+                self.assertEqual(kwargs["app"], application)
+                self.assertEqual(kwargs["api_url"], f"http://127.0.0.1:{client._port}")
+                speculos_args = kwargs["args"]
+                client_seeds.add(get_next_in_list(speculos_args, "--seed"))
+                client_rngs.add(get_next_in_list(speculos_args, "--deterministic-rng"))
+                client_priv_keys.add(get_next_in_list(speculos_args, "--user-private-key"))
+                client_attestations.add(get_next_in_list(speculos_args, "--attestation-key"))
+                api_port = int(get_next_in_list(speculos_args, "--api-port"))
+                client_api_ports.add(client._port)
+                apdu_port = int(get_next_in_list(speculos_args, "--apdu-port"))
+                client_apdu_ports.add(client._port)
+
+                # ports given as original arguments are overridden
+                self.assertNotEqual(api_port, arg_api_port)
+                self.assertNotEqual(apdu_port, arg_api_port)
+                # API port has been overridden by a generated port
+                # (APDU port too, but it is not stored into SpeculosBackend)
+                self.assertEqual(client._port, api_port)
+
+                self.assertIsInstance(client, SpeculosBackend)
+                self.assertIsInstance(client._client, MagicMock)
+
+            # all API ports are different
+            self.assertEqual(len(client_api_ports), client_number)
+            # all APDU ports are different
+            self.assertEqual(len(client_apdu_ports), client_number)
+            # all seeds ports are different
+            self.assertEqual(len(client_seeds), client_number)
+            # all RNGs are different
+            self.assertEqual(len(client_rngs), client_number)
+            # all private keys are different
+            self.assertEqual(len(client_priv_keys), client_number)
+            # all attestations are different
+            self.assertEqual(len(client_attestations), client_number)


### PR DESCRIPTION
## What it does

This feature allows to declare several Speculos clients at once.

It is useful for testing an application which works with several instances of itself.

Usage example:
```python
@pytest.fixture
def clients():
    from ragger.backend import SpeculosBackend
    from ragger.firmware import Firmware
    s1, s2 = SpeculosBackend.batch('build/nanos/bin/app.elf',
                                   Firmware.NANOS,
                                   2,
                                   args=["--display", "qt"])
    with s1, s2:
        yield ClientWrapper(s1), ClientWrapper(s2)

def test_hello(clients):
    client1, client2 = clients
    name = client1.get_name()
    client2.cheer(name)
```

## Dependencies

- Needs [Speculos changes](https://github.com/LedgerHQ/speculos/pull/440/files)
- Needs [Ledgered changes](https://github.com/LedgerHQ/ledgered/pull/12/files)

## Other thoughts

At first I was thinking of adding a related fixture in `conftest/base_conftest.py`. However it would require a **lot** of  modification all around the place to get the other relevant fixtures / values (backend, firmware, options, ...), leading to either extensive refactorization and/or having lots of code duplication.
On top of that, the fixture would be only valid for `Speculos`, not the other backends (maybe at some point if we are confident with USB ports handling, but that's a big if, in any case not for now).
And finally it would probably not be used by lots of folks anyway.

So I didn't.