### PR TITLE
[fix] Removing 'frozen' from ExceptionRAPDU dataclass to allow Python…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.2] - 2024-01-31
+
+### Fixed
+- Removing the `frozen` attribute for `ExceptionRAPDU` dataclass, as Python3.11 `contextlib` needs
+  the exception class it throws to be RW.
+
 ## [1.14.1] - 2024-01-19
 
 ### Fixed
-- Update Ragger dependency versions (Speculos, LedgerComm, ledgerCTL), so that latest features can
-  leverage recent features
+- Update Ragger dependency versions (Speculos, LedgerComm, ledgerCTL), so that it can leverage recent
+  features.
 
 ## [1.14.0] - 2024-01-19
 

--- a/src/ragger/error.py
+++ b/src/ragger/error.py
@@ -16,7 +16,7 @@
 from dataclasses import dataclass
 
 
-@dataclass(frozen=True)
+@dataclass
 class ExceptionRAPDU(Exception):
     """
     Depending on the :class:`RaisePolicy <ragger.backend.interface.RaisePolicy>`,


### PR DESCRIPTION
…3.11 contextlib to work as expected