### PR TITLE
Removing references to 'test.pypi.org' index, or the 'develop' branch

### DIFF
--- a/.github/workflows/build_and_tests.yml
+++ b/.github/workflows/build_and_tests.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Build & install
       run: |
-        pip install --extra-index-url https://test.pypi.org/simple/ -U .[tests,all_backends]
+        pip install -U .[tests,all_backends]
         pip install -U click>=8
 
     - name: Download app binaries
@@ -81,14 +81,8 @@ jobs:
     - name: Build Ragger Python package
       run: |
         pip install --upgrade pip build twine
-        if [[ ${{ github.ref }} == "refs/tags/"* ]]; \
-        then \
-            python -m build; \
-            pip install .
-        else \
-            PIP_EXTRA_INDEX_URL=https://test.pypi.org/simple/ python -m build; \
-            pip install --extra-index-url https://test.pypi.org/simple/ .
-        fi
+        python -m build
+        pip install .
         python -m twine check dist/*
         echo "TAG_VERSION=$(python -c 'from ragger import __version__; print(__version__)')" >> "$GITHUB_ENV"
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,13 +26,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install graphviz
       - name: Install Python dependencies
-        run: |
-          if [[ ${{ github.ref }} == "refs/tags/"* ]]; \
-          then \
-              pip install .[doc]
-          else \
-              pip install --extra-index-url https://test.pypi.org/simple/ .[doc]
-          fi
+        run: pip install .[doc]
       - name: Generating automatic resources
         run: (cd doc && make gen_resources)
       - name: Generate the documentation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ragger
 
-[![codecov](https://codecov.io/gh/LedgerHQ/ragger/branch/develop/graph/badge.svg)](https://codecov.io/gh/LedgerHQ/ragger)
+[![codecov](https://codecov.io/gh/LedgerHQ/ragger/branch/master/graph/badge.svg)](https://codecov.io/gh/LedgerHQ/ragger)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=LedgerHQ_ragger&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=LedgerHQ_ragger)
 [![CodeQL](https://github.com/LedgerHQ/ragger/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/LedgerHQ/ragger/actions/workflows/codeql-analysis.yml)
 
@@ -32,7 +32,7 @@ More complete documentation can be found [here](https://ledgerhq.github.io/ragge
 
 ### Python package
 
-Ragger is available on https://pypi.org. To install it, just run:
+Ragger is available on https://pypi.org. To install it fully, just run:
 
 ```
 pip install ragger[all_backends]

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -8,7 +8,7 @@ installed with ``pip``:
 
 .. code-block:: bash
 
-   pip install --extra-index-url https://test.pypi.org/simple/ ragger
+   pip install ragger
 
 
 By default - to avoid wasting useless time and space - the ``ragger`` package

--- a/doc/tutorial_installation.rst
+++ b/doc/tutorial_installation.rst
@@ -7,16 +7,9 @@ dependencies:
 
 .. code-block:: bash
 
-   $ pip install --extra-index-url https://test.pypi.org/simple/ ragger[speculos]
+   $ pip install ragger[speculos]
 
-Some explanation on arguments:
-
-- ``--extra-index-url https://test.pypi.org/simple/`` is necessary to get the
-  latest version of ``Ragger``, as it is currently not deployed on the
-  stable ``pypi`` repositories.
-- ``ragger[speculos]`` means than Speculos and its dependencies will also
-  be installed. ``Ragger`` tries to uncouple its dependencies so that only
-  what is needed is installed.
-  All the extras can be seen
-  `in the setup.cfg <https://github.com/LedgerHQ/ragger/blob/develop/setup.cfg#L36-L100>`_
-  file.
+``ragger[speculos]`` means than Speculos and its dependencies will also be
+installed. ``Ragger`` tries to uncouple its dependencies so that only what is
+needed is installed. All the extras can be seen in the `setup.cfg
+<https://github.com/LedgerHQ/ragger/blob/master/setup.cfg#L39-L74>`_ file.

--- a/src/ragger/backend/__init__.py
+++ b/src/ragger/backend/__init__.py
@@ -16,9 +16,8 @@
 from .interface import BackendInterface, RaisePolicy
 from .stub import StubBackend
 
-
-ERROR_MSG = "This backend needs {}. Please install this package (run `pip install " \
-    "--extra-index-url https://test.pypi.org/simple/ ragger[{}]` or check this address: '{}')"
+ERROR_MSG = ("This backend needs {}. Please install this package (run `pip install ragger[{}]` or "
+             "check this address: '{}')")
 
 try:
     from .speculos import SpeculosBackend

--- a/template/usage.md
+++ b/template/usage.md
@@ -8,8 +8,8 @@ This framework allows testing the application on the Speculos emulator or on a r
 ### Install ragger and dependencies
 
 ```
-pip install --extra-index-url https://test.pypi.org/simple/ -r requirements.txt
 sudo apt-get update && sudo apt-get install qemu-user-static
+pip install .[speculos]
 ```
 
 ### Compile the application
@@ -61,7 +61,7 @@ Standard useful pytest options
     -s              enable logs for successful tests, on Speculos it will enable app logs if compiled with DEBUG=1
     -k <testname>   only run the tests that contain <testname> in their names
     --tb=short      in case of errors, formats the test traceback in a readable way
-``` 
+```
 
 Custom pytest options
 ```
@@ -72,4 +72,3 @@ Custom pytest options
     --log_apdu_file <filepath>  log all apdu exchanges to the file in parameter. The previous file content is erased
     --seed                      on Speculos, use the seed (mnemonic) provided.
 ```
-


### PR DESCRIPTION
As now `master` is the default branch, and all packages go to regular `pypi.org`