### PR TITLE
Adding the swipe gesture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.19.0] - 2024-05-??
+## [1.19.0] - 2024-05-14
 
 ### Added
 - firmware/navigation: Adding swipe capabilities for Flex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] - 2024-05-??
+
+### Added
+- firmware/navigation: Adding swipe capabilities for Flex
+
 ## [1.18.2] - 2024-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - firmware/navigation: Adding swipe capabilities for Flex
 
+### Changed
+- navigation: scenarios now use `Firmware` enum rather than strings
+
 ## [1.18.2] - 2024-05-06
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ doc = [
     "docutils==0.16",
 ]
 speculos = [
-    "speculos>=0.8.5",
+    "speculos>=0.9.0",
     "mnemonic",
 ]
 ledgercomm = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ doc = [
     "docutils==0.16",
 ]
 speculos = [
-    "speculos>=0.9.0",
+    "speculos>=0.9.1",
     "mnemonic",
 ]
 ledgercomm = [

--- a/src/ragger/backend/interface.py
+++ b/src/ragger/backend/interface.py
@@ -344,6 +344,37 @@ class BackendInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def finger_swipe(self,
+                     x: int = 0,
+                     y: int = 0,
+                     direction: str = "left",
+                     delay: float = 0.5) -> None:
+        """
+        Performs a finger swipe on the device screen.
+
+        This method may be left void on backends connecting to physical devices,
+        where a physical interaction must be performed instead.
+        This will prevent the instrumentation to fail (the void method won't
+        raise `NotImplementedError`), but the instrumentation flow will probably
+        get stuck (on further call to `receive` for instance) until the expected
+        action is performed on the device.
+
+        :param x: The x coordinate of the initial finger touch.
+        :type x: int
+        :param y: The y coordinate of the initial finger touch.
+        :type y: int
+        :param direction: The direction where to orientate the swipe. Must be in: ['up', 'down',
+                          'left', 'right]
+        :type direction: str
+        :param delay: Delay between finger touch press and release actions.
+        :type delay: float
+
+        :return: None
+        :rtype: NoneType
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def compare_screen_with_snapshot(self,
                                      golden_snap_path: Path,
                                      crop: Optional[Crop] = None,

--- a/src/ragger/backend/physical_backend.py
+++ b/src/ragger/backend/physical_backend.py
@@ -73,6 +73,15 @@ class PhysicalBackend(BackendInterface):
         self.init_gui()
         self._ui.ask_for_touch_action(x, y)
 
+    def finger_swipe(self,
+                     x: int = 0,
+                     y: int = 0,
+                     direction: str = "left",
+                     delay: float = 0.5) -> None:
+        if self._ui is None:
+            return
+        raise NotImplementedError
+
     def compare_screen_with_snapshot(self,
                                      golden_snap_path: Path,
                                      crop: Optional[Crop] = None,

--- a/src/ragger/backend/speculos.py
+++ b/src/ragger/backend/speculos.py
@@ -213,6 +213,13 @@ class SpeculosBackend(BackendInterface):
     def finger_touch(self, x: int = 0, y: int = 0, delay: float = 0.1) -> None:
         self._client.finger_touch(x, y, delay=delay)
 
+    def finger_swipe(self,
+                     x: int = 0,
+                     y: int = 0,
+                     direction: str = "left",
+                     delay: float = 0.1) -> None:
+        self._client.finger_swipe(x, y, direction=direction, delay=delay)
+
     def _save_screen_snapshot(self, snap: BytesIO, path: Path) -> None:
         self.logger.info(f"Saving screenshot to image '{path}'")
         img = Image.open(snap)

--- a/src/ragger/backend/stub.py
+++ b/src/ragger/backend/stub.py
@@ -66,6 +66,13 @@ class StubBackend(BackendInterface):
     def finger_touch(self, x: int = 0, y: int = 0, delay: float = 0.5) -> None:
         pass
 
+    def finger_swipe(self,
+                     x: int = 0,
+                     y: int = 0,
+                     direction: str = "left",
+                     delay: float = 0.5) -> None:
+        pass
+
     def compare_screen_with_snapshot(self,
                                      golden_snap_path: Path,
                                      crop: Optional[Crop] = None,

--- a/src/ragger/firmware/touch/element.py
+++ b/src/ragger/firmware/touch/element.py
@@ -35,3 +35,12 @@ class Element:
     @property
     def positions(self):
         return POSITIONS[str(self.__class__.__name__)][self.firmware]
+
+
+class Center(Element):
+
+    def swipe_left(self):
+        self.client.finger_swipe(*self.positions, direction="left")
+
+    def swipe_right(self):
+        self.client.finger_swipe(*self.positions, direction="right")

--- a/src/ragger/firmware/touch/positions.py
+++ b/src/ragger/firmware/touch/positions.py
@@ -55,6 +55,10 @@ STAX_BUTTON_ABOVE_LOWER_MIDDLE = Position(200, 515)
 FLEX_BUTTON_ABOVE_LOWER_MIDDLE = Position(240, 435)
 
 POSITIONS = {
+    "Center": {
+        Firmware.STAX: STAX_CENTER,
+        Firmware.FLEX: FLEX_CENTER,
+    },
     "ChoiceList": {
         Firmware.STAX: {
             # Up to 6 (5?) choice in a list

--- a/src/ragger/navigator/instruction.py
+++ b/src/ragger/navigator/instruction.py
@@ -30,6 +30,10 @@ class NavInsID(BaseNavInsID):
 
     # Navigation instructions for Stax devices
     TOUCH = auto()
+    SWIPE = auto()
+    SWIPE_CENTER_TO_LEFT = auto()
+    SWIPE_CENTER_TO_RIGHT = auto()
+
     # possible headers
     RIGHT_HEADER_TAP = auto()
     EXIT_HEADER_TAP = auto()

--- a/src/ragger/navigator/navigation_scenario.py
+++ b/src/ragger/navigator/navigation_scenario.py
@@ -23,8 +23,12 @@ class NavigationScenarioData:
             self.pattern = "^Approve$" if approve else "^Reject$"
 
         elif device in [Firmware.STAX, Firmware.FLEX]:
-            if use_case == UseCase.ADDRESS_CONFIRMATION:
+            if device == Firmware.STAX:
                 self.navigation = NavInsID.USE_CASE_REVIEW_TAP
+            else:
+                self.navigation = NavInsID.SWIPE_CENTER_TO_LEFT
+
+            if use_case == UseCase.ADDRESS_CONFIRMATION:
                 if approve:
                     self.validation = [NavInsID.USE_CASE_ADDRESS_CONFIRMATION_CONFIRM]
                 else:
@@ -32,10 +36,6 @@ class NavigationScenarioData:
                 self.pattern = "^Confirm$"
 
             elif use_case == UseCase.TX_REVIEW:
-                if device == Firmware.STAX:
-                    self.navigation = NavInsID.USE_CASE_REVIEW_TAP
-                else:
-                    self.navigation = NavInsID.SWIPE_CENTER_TO_LEFT
                 if approve:
                     self.validation = [NavInsID.USE_CASE_REVIEW_CONFIRM]
                 else:

--- a/src/ragger/navigator/navigation_scenario.py
+++ b/src/ragger/navigator/navigation_scenario.py
@@ -31,7 +31,10 @@ class NavigationScenarioData:
                 self.pattern = "^Confirm$"
 
             elif use_case == UseCase.TX_REVIEW:
-                self.navigation = NavInsID.USE_CASE_REVIEW_TAP
+                if device.startswith("stax"):
+                    self.navigation = NavInsID.USE_CASE_REVIEW_TAP
+                else:
+                    self.navigation = NavInsID.SWIPE_CENTER_TO_LEFT
                 if approve:
                     self.validation = [NavInsID.USE_CASE_REVIEW_CONFIRM]
                 else:

--- a/src/ragger/navigator/touch_navigator.py
+++ b/src/ragger/navigator/touch_navigator.py
@@ -36,6 +36,9 @@ class TouchNavigator(Navigator):
             NavInsID.WAIT_FOR_TEXT_ON_SCREEN: backend.wait_for_text_on_screen,
             NavInsID.WAIT_FOR_TEXT_NOT_ON_SCREEN: backend.wait_for_text_not_on_screen,
             NavInsID.TOUCH: backend.finger_touch,
+            NavInsID.SWIPE: backend.finger_swipe,
+            NavInsID.SWIPE_CENTER_TO_LEFT: screen.center.swipe_left,
+            NavInsID.SWIPE_CENTER_TO_RIGHT: screen.center.swipe_right,
             # possible headers
             NavInsID.RIGHT_HEADER_TAP: screen.right_header.tap,
             NavInsID.EXIT_HEADER_TAP: screen.exit_header.tap,

--- a/tests/unit/backend/test_interface.py
+++ b/tests/unit/backend/test_interface.py
@@ -46,6 +46,9 @@ class DummyBackend(BackendInterface):
     def finger_touch(self, *args, **kwargs):
         self.mock.finger_touch(*args, **kwargs)
 
+    def finger_swipe(self, *args, **kwargs):
+        self.mock.finger_touch(*args, **kwargs)
+
     def compare_screen_with_snapshot(self, snap_path, crop=None) -> bool:
         return self.mock.compare_screen_with_snapshot()
 

--- a/tests/unit/navigator/test_navigation_scenario.py
+++ b/tests/unit/navigator/test_navigation_scenario.py
@@ -15,7 +15,7 @@ class TestNavigationScenario(TestCase):
         self.firmware = Firmware.NANOS
         self.callbacks = dict()
         self.navigator = MagicMock()
-        self.navigate_with_scenario = NavigateWithScenario(self.navigator, self.firmware.device,
+        self.navigate_with_scenario = NavigateWithScenario(self.navigator, self.firmware,
                                                            "test_name", self.directory)
 
     def tearDown(self):


### PR DESCRIPTION
- Adding proxy `finger_swipe` methods in the backends, only really implemented in Speculos for now (need >= v0.9.0)
   - GUI-specific implementations still need to be done (in another PR?)
- Added an `Center(Element)` (position-only class, not tied to a layout or a use case).
  The thing is, a "swipe" is a bit like a "touch", it is not attached to a specific layout or use case. Still, I feel like basic swipe should be usable from anywhere.
  So I added a basic swipe like the touch, but also 2 more specific instructions: `SWIPE_CENTER_TO_LEFT` and `SWIPE_CENTER_TO_RIGHT` which I hope will embed 90% (100%? :crossed_fingers: ) of current use cases.
- Changed the `UseCase.TX_REVIEW` scenario to use the swipe instead of the tap.
  - This may need some thinking, as this specific use case may be better having a "next" method rather than a "tap" one. And it would be our responsibility to implement either a swipe or a tap inside it, directly into the `firmare` module (it should be managed there afterall). But I don't had time to think of it more.


### Tested on 
- monero tests
 ```--- a/tests/monero_client/monero_cmd.py
+++ b/tests/monero_client/monero_cmd.py
@@ -229,7 +229,7 @@ class MoneroCmd(MoneroCryptoCmd):
             instructions = get_nano_review_instructions(1)
         else:
             instructions = [
-                NavIns(NavInsID.USE_CASE_REVIEW_TAP)
+                NavInsID.SWIPE_CENTER_TO_LEFT
             ]
```

- Ethereum tests - no changes as it is abstracted into the `UseCase.TX_REVIEW` scenario