### PR TITLE
[add] Fixture to customize SpeculosClient arguments

### DIFF
--- a/.github/workflows/fast-checks.yml
+++ b/.github/workflows/fast-checks.yml
@@ -63,3 +63,4 @@ jobs:
       with:
         builtin: clear,rare
         check_filenames: true
+        ignore_words_list: assertIn,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2024-05-31
+
+### Added
+- conftest: Overridable fixture to inject custom arguments into the Speculos client
+
 ## [1.19.0] - 2024-05-14
 
 ### Added

--- a/tests/unit/conftests/test_base_conftest.py
+++ b/tests/unit/conftests/test_base_conftest.py
@@ -48,16 +48,26 @@ class TestBaseConftest(TestCase):
             app_path, _ = prepare_base_dir(temp_dir)
             with patch("ragger.conftest.base_conftest.Manifest", ManifestMock):
                 result_app, result_args = bc.prepare_speculos_args(temp_dir, Firmware.STAX, False,
-                                                                   self.seed)
+                                                                   self.seed, [])
             self.assertEqual(result_app, app_path)
             self.assertEqual(result_args, {"args": ["--seed", self.seed]})
+
+    def test_prepare_speculos_args_with_custom_args(self):
+        arg = "whatever"
+        with temporary_directory() as temp_dir:
+            app_path, _ = prepare_base_dir(temp_dir)
+            with patch("ragger.conftest.base_conftest.Manifest", ManifestMock):
+                result_app, result_args = bc.prepare_speculos_args(temp_dir, Firmware.STAX, False,
+                                                                   self.seed, [arg])
+            self.assertEqual(result_app, app_path)
+            self.assertEqual(result_args, {"args": [arg, "--seed", self.seed]})
 
     def test_prepare_speculos_args_simple_with_gui(self):
         with temporary_directory() as temp_dir:
             app_path, _ = prepare_base_dir(temp_dir)
             with patch("ragger.conftest.base_conftest.Manifest", ManifestMock):
                 result_app, result_args = bc.prepare_speculos_args(temp_dir, Firmware.STAX, True,
-                                                                   self.seed)
+                                                                   self.seed, [])
             self.assertEqual(result_app, app_path)
             self.assertEqual(result_args, {"args": ["--display", "qt", "--seed", self.seed]})
 
@@ -67,7 +77,7 @@ class TestBaseConftest(TestCase):
             with patch("ragger.conftest.base_conftest.conf.OPTIONAL.MAIN_APP_DIR", "./deps"):
                 with patch("ragger.conftest.base_conftest.Manifest", ManifestMock) as manifest:
                     result_app, result_args = bc.prepare_speculos_args(
-                        temp_dir, Firmware.STAX, False, self.seed)
+                        temp_dir, Firmware.STAX, False, self.seed, [])
             self.assertEqual(result_app, dep_path)
             self.assertEqual(result_args, {"args": [f"-l{app_path}", "--seed", self.seed]})
 
@@ -78,7 +88,7 @@ class TestBaseConftest(TestCase):
                        ["more than 1 elt"]):
                 with patch("ragger.conftest.base_conftest.Manifest", ManifestMock):
                     with self.assertRaises(ValueError):
-                        bc.prepare_speculos_args(temp_dir, Firmware.STAX, False, self.seed)
+                        bc.prepare_speculos_args(temp_dir, Firmware.STAX, False, self.seed, [])
 
     def test_prepare_speculos_args_sideloaded_apps_ok(self):
         lib1_bin, lib1_name, lib2_bin, lib2_name = "lib1", "name1", "lib2", "name2"
@@ -99,7 +109,7 @@ class TestBaseConftest(TestCase):
 
                     with patch("ragger.conftest.base_conftest.Manifest", ManifestMock):
                         result_app, result_args = bc.prepare_speculos_args(
-                            temp_dir, Firmware.STAX, False, self.seed)
+                            temp_dir, Firmware.STAX, False, self.seed, [])
                     self.assertEqual(result_app, app_path)
                     self.assertEqual(
                         result_args, {
@@ -111,7 +121,7 @@ class TestBaseConftest(TestCase):
 
     def test_create_backend_nok(self):
         with self.assertRaises(ValueError):
-            bc.create_backend(None, "does not exist", None, None, None, None)
+            bc.create_backend(None, "does not exist", None, None, None, None, [])
 
     def test_create_backend_speculos(self):
         with patch("ragger.conftest.base_conftest.SpeculosBackend") as backend:
@@ -119,15 +129,17 @@ class TestBaseConftest(TestCase):
                 prepare_base_dir(temp_dir)
                 with patch("ragger.conftest.base_conftest.Manifest", ManifestMock):
                     result = bc.create_backend(temp_dir, "Speculos", Firmware.STAX, False, None,
-                                               self.seed)
+                                               self.seed, [])
                 self.assertEqual(result, backend())
 
     def test_create_backend_ledgercomm(self):
         with patch("ragger.conftest.base_conftest.LedgerWalletBackend") as backend:
-            result = bc.create_backend(None, "ledgerWALLET", Firmware.STAX, False, None, self.seed)
+            result = bc.create_backend(None, "ledgerWALLET", Firmware.STAX, False, None, self.seed,
+                                       [])
             self.assertEqual(result, backend())
 
     def test_create_backend_ledgerwallet(self):
         with patch("ragger.conftest.base_conftest.LedgerCommBackend") as backend:
-            result = bc.create_backend(None, "LedgerComm", Firmware.STAX, False, None, self.seed)
+            result = bc.create_backend(None, "LedgerComm", Firmware.STAX, False, None, self.seed,
+                                       [])
             self.assertEqual(result, backend())


### PR DESCRIPTION
This feature allows to inject custom parameters to the underlying `SpeculosClient` instance, allowing to further tweak its behavior (forcing a port for instance).

One would need to override the `additional_speculos_arguments` fixture in its `conftest.py` file:
```
import pytest
from typing import List
from ragger.conftest import configuration

pytest_plugins = ("ragger.conftest.base_conftest", )

@pytest.fixture(scope=configuration.OPTIONAL.BACKEND_SCOPE)
def additional_speculos_arguments() -> List[str]:
    return ["--api-port", "5000"]
```

This will work with a Speculos backend and only a Speculos backend.

If arguments are duplicated vs. the ones already computed and added by the Ragger fixtures (like the model, the display type, the seed, ...), the behavior is not specified. Be aware of it!