### PR TITLE
Navigation scenario depends on elf metadata

### DIFF
--- a/src/ragger/backend/interface.py
+++ b/src/ragger/backend/interface.py
@@ -46,6 +46,7 @@ class BackendInterface(ABC):
         self._firmware = firmware
         self._last_async_response: Optional[RAPDU] = None
         self.raise_policy = RaisePolicy.RAISE_ALL_BUT_0x9000
+        self.graphics: str = "Unknown"
 
         if log_apdu_file:
             set_apdu_logger_file(log_apdu_file=log_apdu_file)

--- a/src/ragger/backend/speculos.py
+++ b/src/ragger/backend/speculos.py
@@ -25,6 +25,7 @@ from typing import Optional, Generator, List, Type, TypeVar
 from time import time, sleep
 from re import match
 
+from ledgered import binary
 from speculos.client import SpeculosClient, screenshot_equal, ApduResponse, ApduException
 from speculos.mcu.seproxyhal import TICKER_DELAY
 
@@ -103,7 +104,13 @@ class SpeculosBackend(BackendInterface):
         speculos_args.extend(args)
         kwargs[self._ARGS_KEY] = speculos_args
 
+        self.graphics: str = "Unknown"
+        if Path(application).is_file():
+            bin_data = binary.LedgerBinaryApp(application)
+            self.graphics = bin_data.sections.sdk_graphics
+
         self.logger.info("Speculos binary: '%s'", application)
+        self.logger.info("  SDK Library: '%s'", self.graphics)
         self.logger.info("Speculos options: '%s'", " ".join(kwargs[self._ARGS_KEY]))
         self._client: SpeculosClient = SpeculosClient(app=str(application),
                                                       api_url=self.url,

--- a/src/ragger/navigator/navigator.py
+++ b/src/ragger/navigator/navigator.py
@@ -56,6 +56,9 @@ class Navigator(ABC):
         self._callbacks = callbacks
         self._golden_run = golden_run
 
+    def get_sdk_graphic(self) -> str:
+        return self._backend.graphics
+
     def _get_snaps_dir_path(self, path: Path, test_case_name: Union[Path, str],
                             is_golden: bool) -> Path:
         if is_golden:


### PR DESCRIPTION
Update navigation_scenario manager to support conditional execution based on elf metadata:
- Swipe is introduced on Stax with API_LEVEL_21; need to support both `Tap to continue` and `Swipe to review`.
- NBGLv2 on Nano devices needs a new a validation step (Cf. https://github.com/LedgerHQ/app-boilerplate/pull/123)