### PR TITLE
Correct position of choice 1 in stax choicelist

### DIFF
--- a/src/ragger/firmware/touch/positions.py
+++ b/src/ragger/firmware/touch/positions.py
@@ -63,7 +63,7 @@ POSITIONS = {
     "ChoiceList": {
         Firmware.STAX: {
             # Up to 6 (5?) choice in a list
-            1: Position(200, 190),
+            1: Position(200, 180),
             2: Position(200, 260),
             3: Position(200, 340),
             4: Position(200, 410),


### PR DESCRIPTION
The position on stax for choicelist option 1 was incorrect. using choose(1) would not result in choice 1 but choice 2. Corrected it to right value.