### PR TITLE
Avoid import error on tesseract when using Ragger with Speculos only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.26.0] - 2025-??-??
+## [1.26.0] - 2025-02-06
 
 ### Added
 
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `_actionhint` element location (covered previously by the snapshot image)
+- Physical backend -specific imports (`PIL`, `tesseract`) are postponed to avoid raising when using
+  Speculos only
 
 ## [1.25.0] - 2024-12-20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,13 @@ ledgercomm = [
     "ledgercomm[hid]>=1.2.1",
     "pyqt5",
     "pytesseract",
+    "pillow",
 ]
 ledgerwallet = [
     "ledgerwallet>=0.4.0",
     "pyqt5",
     "pytesseract",
+    "pillow",
 ]
 all_backends = [
     "ragger[speculos]",

--- a/src/ragger/backend/physical_backend.py
+++ b/src/ragger/backend/physical_backend.py
@@ -14,8 +14,6 @@
    limitations under the License.
 """
 from pathlib import Path
-from PIL import Image, ImageOps
-from pytesseract import image_to_data, Output
 from types import TracebackType
 from typing import List, Optional, Type
 
@@ -104,6 +102,16 @@ class PhysicalBackend(BackendInterface):
             return False
 
     def compare_screen_with_text(self, text: str) -> bool:
+        # Only this method needs these dependencies, which needs at least one physical backend to
+        # be installed. By postponing the imports, we avoid an import error when using only Speculos
+        try:
+            from PIL import Image, ImageOps
+            from pytesseract import image_to_data, Output
+        except ImportError as error:
+            raise ImportError(
+                "This feature needs at least one physical backend. "
+                "Please install ragger[ledgercomm] or ragger[ledgerwallet]") from error
+
         if self._ui is None:
             return True
         self.init_gui()


### PR DESCRIPTION
Before:

```bash
$ pip install ragger[speculos]
[...]
$ python -c "from ragger.backend.physical_backend import PhysicalBackend"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/lpascal/.virtualenvs/test2/lib/python3.10/site-packages/ragger/backend/physical_backend.py", line 18, in <module>
    from pytesseract import image_to_data, Output
ModuleNotFoundError: No module named 'pytesseract'
```

Now:

```
$ pip install ragger[speculos]
[...]
$ python -c "from ragger.backend.physical_backend import PhysicalBackend"


<no error>
```