### PR TITLE
Pushing package on Artifactory

### DIFF
--- a/.github/workflows/build_and_tests.yml
+++ b/.github/workflows/build_and_tests.yml
@@ -13,6 +13,10 @@ on:
       - master
       - develop
 
+permissions:
+  id-token: write
+  attestations: write
+
 jobs:
 
   build_boilerplate_application:
@@ -95,7 +99,7 @@ jobs:
   package_and_deploy:
     name: Build and deploy Ragger Python Package
     needs: [build_install_test]
-    runs-on: ubuntu-latest
+    runs-on: public-ledgerhq-shared-small
     steps:
 
     - name: Clone
@@ -145,6 +149,35 @@ jobs:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PUBLIC_API_TOKEN  }}
         TWINE_NON_INTERACTIVE: 1
+
+    - name: Login to Ledger Artifactory
+      if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+      timeout-minutes: 10
+      id: jfrog-login
+      uses: LedgerHQ/actions-security/actions/jfrog-login@actions/jfrog-login-1
+
+    - name: Publish Python package on Ledger Artifactory
+      if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+      run: python -m twine upload dist/*
+      env:
+        TWINE_REPOSITORY_URL: https://jfrog.ledgerlabs.net/artifactory/api/pypi/embedded-apps-pypi-prod-green
+        TWINE_USERNAME: ${{ steps.jfrog-login.outputs.oidc-user }}
+        TWINE_PASSWORD: ${{ steps.jfrog-login.outputs.oidc-token }}
+        TWINE_NON_INTERACTIVE: 1
+
+    - name: Generate library build attestations
+      if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+      timeout-minutes: 10
+      uses: LedgerHQ/actions-security/actions/attest@actions/attest-1
+      with:
+        subject-path: dist/*
+
+    - name: Sign library artifacts
+      if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+      timeout-minutes: 10
+      uses: LedgerHQ/actions-security/actions/sign-blob@actions/sign-blob-1
+      with:
+        path: dist
 
     - name: Publish a release on the repo
       if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Packages are still pushed on `pypi.org`, but now also on Ledger's Artifactory