### PR TITLE
B2CA-2062: Add the ragger snapshot logs back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.31.0] - 2025-03-26
+
+### Changed
+
+- Reactivate logs like "Saving screenshot to image" (which were removed in v1.29.0)
+
 ## [1.30.0] - 2025-03-21
 
 ### Added

--- a/src/ragger/backend/speculos.py
+++ b/src/ragger/backend/speculos.py
@@ -74,7 +74,6 @@ class SpeculosBackend(BackendInterface):
     _ARGS_KEY = 'args'
     _ARGS_API_PORT_KEY = '--api-port'
     _ARGS_APDU_PORT_KEY = '--apdu-port'
-    ARGS_VERBOSE = '--verbose'
 
     def __init__(self,
                  application: Path,
@@ -94,8 +93,6 @@ class SpeculosBackend(BackendInterface):
         else:
             self._api_port = _get_unused_port_from(self._DEFAULT_API_PORT)
             args.extend([self._ARGS_API_PORT_KEY, str(self._api_port)])
-        # Verbose flag
-        self._verbose = self.ARGS_VERBOSE in speculos_args
         # Inferring the APDU port
         if self._ARGS_APDU_PORT_KEY in speculos_args:
             index = speculos_args.index(self._ARGS_APDU_PORT_KEY)
@@ -224,8 +221,7 @@ class SpeculosBackend(BackendInterface):
         self._client.finger_swipe(x, y, direction=direction, delay=delay)
 
     def _save_screen_snapshot(self, snap: BytesIO, path: Path) -> None:
-        if self._verbose:
-            self.logger.info(f"Saving screenshot to image '{path}'")
+        self.logger.info(f"Saving screenshot to image '{path}'")
         img = Image.open(snap)
         img.save(path)
 

--- a/src/ragger/conftest/base_conftest.py
+++ b/src/ragger/conftest/base_conftest.py
@@ -181,7 +181,7 @@ def prepare_speculos_args(root_pytest_dir: Path,
         speculos_args += ["-p"]
 
     if verbose_speculos:
-        speculos_args += [SpeculosBackend.ARGS_VERBOSE]
+        speculos_args += ["--verbose"]
 
     device = firmware.name
     if device == "nanosp":


### PR DESCRIPTION
Reactivate logs like "Saving screenshot to image"
    
Party revert commit e690b0043f1ddcb02cf332c11d8a50732f0ab75d
