### PR TITLE
blocking apdus revamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage.xml
 build/
 dist/
 __version__.py
+.python-version
 
 tests/snapshots-tmp/
 ledger_app.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.37.0] - 2025-05-16
+
+### Changed
+
+- `exchange_async_raw` on the speculos backend can yield if the apdu has a response or not as a boolean
+
 ## [1.36.1] - 2025-06-16
 
 ### Fixed

--- a/src/ragger/backend/interface.py
+++ b/src/ragger/backend/interface.py
@@ -18,7 +18,7 @@ from contextlib import contextmanager
 from enum import Enum, auto
 from pathlib import Path
 from types import TracebackType
-from typing import Optional, Type, Generator, Any, Iterable
+from typing import Optional, Type, Generator, Any, Iterable, Union
 from ledgered.devices import Device
 from warnings import warn
 
@@ -279,7 +279,7 @@ class BackendInterface(ABC):
 
     @contextmanager
     @abstractmethod
-    def exchange_async_raw(self, data: bytes = b"") -> Generator[None, None, None]:
+    def exchange_async_raw(self, data: bytes = b"") -> Generator[Union[bool, None], None, None]:
         """
         Sends the given APDU to the backend, then gives the control back to the
         caller.

--- a/src/ragger/backend/speculos.py
+++ b/src/ragger/backend/speculos.py
@@ -123,10 +123,19 @@ class SpeculosBackend(BackendInterface):
         self._last_screenshot: Optional[BytesIO] = None
         self._home_screenshot: Optional[BytesIO] = None
         self._ticker_paused_count = 0
+        self._apdu_timeout = 0.3
 
     @property
     def url(self) -> str:
         return f"http://127.0.0.1:{self._api_port}"
+
+    @property
+    def apdu_timeout(self) -> float:
+        return self._apdu_timeout
+
+    @apdu_timeout.setter
+    def apdu_timeout(self, value: float) -> None:
+        self._apdu_timeout = value
 
     def _retrieve_client_screen_content(self) -> dict:
         raw_content = self._client.get_current_screen_content()
@@ -209,7 +218,7 @@ class SpeculosBackend(BackendInterface):
                                                p1=data[2],
                                                p2=data[3],
                                                data=data[5:]) as response:
-            yield has_data_available(response, timeout=0.2)
+            yield has_data_available(response, timeout=self.apdu_timeout)
             self._last_async_response = self._get_last_async_response(response)
 
     def right_click(self) -> None:


### PR DESCRIPTION
Ragger change to avoid sending the same APDU twice - an approach that is used to perform  user interaction in BTC (  new and legacy) apps tests when :

- apdu_exchange()  is executed that may trigger TimeoutError  exception at the end of 1s
- if it happens exchange_async() is called that sends the same APDU 2nd time (!), then uses python's yield functionality that allows the UI navigation waiting for the response

The issue is that:
- it is not "absolutely" normal to send the 2nd identical APDU
- with io revamp the OS teams wants to logically forbid this possibility

With the new approach:
* the APDU is sent only once using `exchange_async_raw()`
*  if at end of timeout (parameterized (?),  BTC needs 1s for instance) or earlier if there is a response than we just handle this response
* if not we start the UI interaction still waiting for the response (at the end of Ragger/Speculos 20s it will return error) 

Blocks:
* https://github.com/LedgerHQ/app-bitcoin/pull/291
* https://github.com/LedgerHQ/app-bitcoin-new/pull/335
 

Tested locally with:
* :white_check_mark: this ragger + 1s fix built locally, Speculos=dmo_io_revamp(5e9cd4e) built locally, SDK = API_LEVEL_24(f3eaf88), `app-bitcoin-new` modified as https://github.com/LedgerHQ/app-bitcoin-new/pull/335,  Flex 
* :white_check_mark: this ragger + 1s fix built locally, Speculos=master built locally, SDK = API_LEVEL_22, `app-bitcoin-new` as per `develop (03afbde)`,  Flex  - no regression.