### PR TITLE
hotfix: yield true on async to notify the action has been completed

### DIFF
--- a/src/ragger/backend/ledgercomm.py
+++ b/src/ragger/backend/ledgercomm.py
@@ -106,7 +106,7 @@ class LedgerCommBackend(PhysicalBackend):
         return result
 
     @contextmanager
-    def exchange_async_raw(self, data: bytes = b"") -> Generator[None, None, None]:
+    def exchange_async_raw(self, data: bytes = b"") -> Generator[bool, None, None]:
         self.send_raw(data)
-        yield
+        yield True
         self._last_async_response = self.receive()

--- a/src/ragger/backend/ledgerwallet.py
+++ b/src/ragger/backend/ledgerwallet.py
@@ -98,7 +98,7 @@ class LedgerWalletBackend(PhysicalBackend):
         return result
 
     @contextmanager
-    def exchange_async_raw(self, data: bytes = b"") -> Generator[None, None, None]:
+    def exchange_async_raw(self, data: bytes = b"") -> Generator[bool, None, None]:
         self.send_raw(data)
-        yield
+        yield True
         self._last_async_response = self.receive()


### PR DESCRIPTION
In reality, the apdu exchange might not be completed, but the physical device is going to block either way till the flow has been done manually