### PR TITLE
Force display to be set when no-nav is on the commandline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.45.1] - 2026-04-27
+
+### Added
+
+- New marker `skip_on_backend(backend)` to skip tests on specific backends
+- New marker `skip_nano` to skip tests on Nano devices
+
+### Fixed
+
+- Force `display` option to be set when `no-nav` is requested
+
 ## [1.45.0] - 2026-03-31
 
 ### Added

--- a/src/ragger/conftest/base_conftest.py
+++ b/src/ragger/conftest/base_conftest.py
@@ -81,7 +81,7 @@ def backend_name(pytestconfig):
 
 @pytest.fixture(scope="session")
 def display(pytestconfig):
-    return pytestconfig.getoption("display")
+    return pytestconfig.getoption("display") or pytestconfig.getoption("no_nav")
 
 
 @pytest.fixture(scope="session")

--- a/src/ragger/conftest/base_conftest.py
+++ b/src/ragger/conftest/base_conftest.py
@@ -502,6 +502,20 @@ def auto_skip_on_backend(request, backend_name):
             pytest.skip(f'⚠️ Not supported on {excluded_backend} backend')
 
 
+@pytest.fixture(autouse=True)
+def auto_skip_nano(request):
+    """Auto-skip tests marked with skip_nano when running on Nano devices."""
+    if request.node.get_closest_marker('skip_nano'):
+        try:
+            device = request.getfixturevalue('device')
+            if device.is_nano:
+                pytest.skip("⚠️ Not yet supported on Nano devices")
+        except pytest.FixtureLookupError:
+            # 'device' is not available when running Ragger's own test suite;
+            # it is always defined in application test suites.
+            pass
+
+
 # This function will look for the 'needs_setup' marker. Example:
 # @pytest.mark.needs_setup('prod_build')
 # If the needed setup is not the one requested, a skip marker will be added
@@ -545,6 +559,11 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "needs_setup(setup_name): skip test if not on the specified setup",
+    )
+
+    config.addinivalue_line(
+        "markers",
+        "skip_nano: skip test on Nano devices",
     )
 
     _setup_log_level(config)

--- a/src/ragger/conftest/base_conftest.py
+++ b/src/ragger/conftest/base_conftest.py
@@ -492,6 +492,16 @@ def use_only_on_backend(request, backend_name):
             pytest.skip(f'skipped on this backend: "{current_backend}"')
 
 
+@pytest.fixture(autouse=True)
+def auto_skip_on_backend(request, backend_name):
+    """Auto-skip tests marked with skip_on_backend when running on the specified backend."""
+    marker = request.node.get_closest_marker('skip_on_backend')
+    if marker:
+        excluded_backend = marker.args[0]
+        if excluded_backend == backend_name:
+            pytest.skip(f'⚠️ Not supported on {excluded_backend} backend')
+
+
 # This function will look for the 'needs_setup' marker. Example:
 # @pytest.mark.needs_setup('prod_build')
 # If the needed setup is not the one requested, a skip marker will be added
@@ -519,6 +529,11 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "use_on_backend(backend): skip test if not on the specified backend",
+    )
+
+    config.addinivalue_line(
+        "markers",
+        "skip_on_backend(backend): skip test if on the specified backend",
     )
 
     # fixture with parameter, use with the following syntax


### PR DESCRIPTION
Bonus:

Add 2 new markers to ease test skip:
- `skip_on_backend(backend)` -> This is the reverse of the existing `use_only_on_backend(backend)`
- `skip_nano`
