### PR TITLE
Add tools and fixture to support Code Coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.46.0] - 2026-06-11
+
+### Added
+
+- Test Coverage support with "--coverage"
+
 ## [1.45.3] - 2026-05-11
 
 ### Fixed

--- a/doc/coverage.rst
+++ b/doc/coverage.rst
@@ -1,0 +1,132 @@
+.. _Coverage:
+
+==========================
+ Functional test coverage
+==========================
+
+``Ragger`` can measure the **C code coverage of the firmware** exercised by the
+functional tests, through the ``--coverage`` option. This complements the unit
+tests: it tells which lines of the application sources are actually reached when
+running the :term:`Speculos`-based functional suite.
+
+.. note::
+
+   Coverage is only available on the :term:`Speculos` backend (the application
+   runs as ARM code inside an emulator, which is what makes the measurement
+   possible). The application must be built **with debug symbols**: a default
+   build keeps them, a stripped/release build does not.
+
+
+Usage
+=====
+
+.. code-block:: bash
+
+   # whole suite, single device -> coverage.info (+ coverage_html/ if genhtml is installed)
+   pytest --device flex --coverage
+
+   # custom output path
+   pytest --device flex --coverage --coverage_output cov.info
+
+   # several devices -> one file per device: coverage-<device>.info
+   pytest --device all --coverage
+
+The options added by the plugin are:
+
+- ``--coverage``: enable tracing and produce the lcov file(s) at the end of the
+  session.
+- ``--coverage_output`` (default ``coverage.info``): the output lcov path. With
+  several devices, one file per device is written as ``<stem>-<device>.info``.
+- ``--coverage_exclude``: exclude matching source paths (repo-relative) from the
+  report, typically a vendored submodule. Repeatable, and each value may be a
+  comma-separated list; a pattern matches a path, a leading directory of it, or
+  an fnmatch glob. Example: ``--coverage_exclude my-vendored-submodule``.
+
+An HTML report (``<stem>_html/``) is rendered next to each lcov file when
+``genhtml`` (from the ``lcov`` package) is available; otherwise only the lcov
+file is produced.
+
+.. note::
+
+   SDK/toolchain files (under ``/opt``, ``/usr`` ...) are already dropped
+   automatically because only sources found under the project root are kept.
+   ``--coverage_exclude`` is meant for sources that *are* in the repository but
+   should not be reported, such as a vendored git submodule.
+
+
+Why not gcov?
+=============
+
+The usual C coverage flow relies on **gcov**: the application is compiled with
+``-fprofile-arcs -ftest-coverage``, which produces ``.gcno`` files (the
+build-time call graph) ; at runtime ``libgcov`` writes ``.gcda`` files (the
+execution counters) when the process exits.
+
+That flow **cannot** work on a Ledger application:
+
+- ``libgcov`` is not linked into the firmware,
+- the application never performs a normal libc ``exit()`` under BOLOS/Speculos,
+
+so **no** ``.gcda`` is ever produced. ``Ragger`` therefore does **not** use gcov
+at all (the build is not instrumented). Instead, coverage is reconstructed at
+the **emulator** level, and the gcov building blocks are replaced by equivalents
+that are available without instrumentation:
+
+.. list-table::
+   :header-rows: 1
+
+   * - gcov
+     - Ragger's approach
+   * - ``.gcno`` (build-time address → line map)
+     - the **DWARF line table** (``.debug_line``), already present in the ELF
+   * - ``.gcda`` (runtime counters)
+     - the **QEMU** ``in_asm`` **trace** (which blocks actually ran)
+   * - ``gcov`` merge
+     - intersecting the executed address ranges with the line table
+
+
+How it works
+============
+
+:term:`Speculos` runs the ARM application through ``qemu-arm-static``. The
+coverage pipeline is:
+
+#. **Tracing.** QEMU honours the ``QEMU_LOG=in_asm`` / ``QEMU_LOG_FILENAME``
+   environment variables. With ``in_asm``, QEMU logs the guest assembly of every
+   *translated* basic block. A block is translated the first time it is reached,
+   so "translated" == "executed at least once" == line coverage. (``exec,nochain``
+   would log every execution -- orders of magnitude bigger -- and is not needed.)
+   Enabling this requires no change to Speculos or QEMU: Speculos spawns QEMU
+   with ``Popen`` without an explicit ``env``, so the variables set in
+   ``os.environ`` are inherited. One trace file per QEMU process is written
+   (``cov-<pid>.log``): the backend is usually class-scoped, so several QEMU
+   instances run during a session and each must write its own file.
+
+#. **Rebasing.** Ledger applications are PIC: linked high (e.g. ``0xc0de0000``)
+   but loaded and executed by Speculos at a fixed base (``0x40000000`` for every
+   Cortex-M target). The executed block addresses are rebased back to link
+   addresses.
+
+#. **Mapping.** The rebased ranges are intersected with the DWARF line table of
+   the ELF to determine which source lines were covered.
+
+#. **Output.** A standard lcov ``.info`` tracefile is emitted (uploadable to
+   Codecov, renderable with ``genhtml``). Source paths are made repo-relative by
+   stripping the longest prefix that still resolves to a file under the project
+   root, which drops toolchain/SDK files (``/opt``, ``/usr`` ...).
+
+The implementation lives in :py:mod:`ragger.utils.coverage`; the wiring (option,
+per-device trace directory, end-of-session conversion) is in the ``Ragger``
+``conftest`` and the :py:class:`SpeculosBackend
+<ragger.backend.SpeculosBackend>`.
+
+
+Limitations
+===========
+
+- **Line/block coverage only -- no branch coverage.** We only know that a block
+  ran, not which side of a conditional was taken. Each covered line is reported
+  with a hit count of 1 (presence/absence, not an execution frequency).
+- The application ELF must keep its ``.debug_*`` sections (``-g``).
+- Attribution is done on the optimized build (``-Os``), so the line mapping is as
+  approximate as for any optimized-build coverage (inlining, shared lines).

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,6 +16,7 @@ to develop complex behaviors on devices.
    rationale
    tutorial
    architecture
+   coverage
    source
    faq
    glossary

--- a/doc/source.rst
+++ b/doc/source.rst
@@ -123,3 +123,9 @@ Interface and instructions
 +++++++++++++++++++++
 
 .. autofunction:: ragger.utils.misc.app_path_from_app_name
+
+``ragger.utils.coverage``
++++++++++++++++++++++++++
+
+.. automodule:: ragger.utils.coverage
+   :members: enable, to_lcov, to_html, finalize

--- a/src/ragger/backend/speculos.py
+++ b/src/ragger/backend/speculos.py
@@ -81,8 +81,14 @@ class SpeculosBackend(BackendInterface):
                  application: Path,
                  device: Device,
                  log_apdu_file: Optional[Path] = None,
+                 coverage_trace_dir: Optional[Path] = None,
                  **kwargs):
         super().__init__(device=device, log_apdu_file=log_apdu_file)
+        # ELF and trace directory used for firmware C coverage (see
+        # ragger.utils.coverage). Coverage is off unless a trace dir is given.
+        self._application = Path(application)
+        self._coverage_trace_dir = coverage_trace_dir
+        self._coverage_device_name = device.name
         # crafting Speculos arguments
         args = ["--model", device.name]
         speculos_args: List = kwargs.get(self._ARGS_KEY, list())
@@ -177,6 +183,11 @@ class SpeculosBackend(BackendInterface):
 
     def __enter__(self) -> "SpeculosBackend":
         self.logger.info(f"Starting {self.__class__.__name__} stream")
+        # Enable QEMU tracing before Speculos spawns it: the env vars are
+        # inherited by the QEMU process (Speculos uses Popen without env).
+        if self._coverage_trace_dir is not None:
+            from ragger.utils import coverage
+            coverage.enable(self._coverage_device_name, self._application, self._coverage_trace_dir)
         self._client.__enter__()
 
         # Wait until some text is displayed on the screen.

--- a/src/ragger/conftest/base_conftest.py
+++ b/src/ragger/conftest/base_conftest.py
@@ -24,6 +24,9 @@ BACKENDS = ["speculos", "ledgercomm", "ledgerwallet"]
 
 DEVICES = [device.name for device in Devices()] + ["all", "all_nano", "all_eink"]
 
+# Directory (under the pytest root) where QEMU coverage traces are written.
+COVERAGE_TRACE_ROOT = ".ragger_coverage"
+
 
 def pytest_addoption(parser):
     parser.addoption("--device", choices=DEVICES, required=True)
@@ -67,6 +70,25 @@ def pytest_addoption(parser):
                      default="default",
                      help="Specify the setup fixture (e.g., 'prod_build')",
                      choices=allowed_setups)
+    parser.addoption("--coverage",
+                     action="store_true",
+                     default=False,
+                     help="Trace the app inside Speculos/QEMU and, at the end of the session, "
+                     "emit an lcov firmware coverage file (speculos backend only). The app must "
+                     "be built with debug symbols.")
+    parser.addoption("--coverage_output",
+                     action="store",
+                     default="coverage.info",
+                     help="Output lcov file for --coverage (default: 'coverage.info'). With "
+                     "several devices, one file per device is written as '<stem>-<device>.info'. "
+                     "An HTML report ('<stem>_html/') is also rendered if 'genhtml' is installed.")
+    parser.addoption("--coverage_exclude",
+                     action="append",
+                     default=None,
+                     help="Exclude matching source paths (repo-relative) from --coverage, e.g. a "
+                     "vendored submodule '--coverage_exclude ethereum-plugin-sdk'. Repeatable, and "
+                     "each value may be a comma-separated list. Patterns match a path, a leading "
+                     "directory of it, or an fnmatch glob.")
 
 
 @pytest.fixture(scope="session")
@@ -166,18 +188,43 @@ def stack_consumption_hooks(request, get_stack_consumption: bool):
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
-    if not _stack_consumption_results:
-        return
-    terminalreporter.write_sep("=", "stack consumption summary")
-    for test_name, consumption in sorted(_stack_consumption_results.items()):
-        terminalreporter.write_line(f"  {consumption:>8} bytes  {test_name}")
-    worst_test, worst_value = max(_stack_consumption_results.items(), key=lambda x: x[1])
-    terminalreporter.write_sep("-", f"worst case: {worst_value} bytes  ({worst_test})")
+    if _stack_consumption_results:
+        terminalreporter.write_sep("=", "stack consumption summary")
+        for test_name, consumption in sorted(_stack_consumption_results.items()):
+            terminalreporter.write_line(f"  {consumption:>8} bytes  {test_name}")
+        worst_test, worst_value = max(_stack_consumption_results.items(), key=lambda x: x[1])
+        terminalreporter.write_sep("-", f"worst case: {worst_value} bytes  ({worst_test})")
+
+    if config.getoption("coverage"):
+        from ragger.utils import coverage
+        project_root = find_project_root_dir(Path(config.rootpath).resolve())
+        output = Path(config.getoption("coverage_output"))
+        if not output.is_absolute():
+            output = Path(config.invocation_params.dir) / output
+        # Flatten the repeatable option and allow comma-separated values.
+        exclude = [
+            pat for opt in (config.getoption("coverage_exclude") or []) for pat in opt.split(",")
+        ]
+        results = coverage.finalize(project_root, output, exclude=exclude)
+        terminalreporter.write_sep("=", "firmware coverage")
+        if not results:
+            terminalreporter.write_line("  no coverage produced (see warnings above)")
+        for device, files, cov, total, out, html in results:
+            pct = 100.0 * cov / total if total else 0.0
+            terminalreporter.write_line(
+                f"  {device}: {cov}/{total} lines ({pct:.1f}%), {files} files -> {out}")
+            if html is not None:
+                terminalreporter.write_line(f"  {' ' * len(device)}  HTML: {html}")
 
 
 @pytest.fixture(scope="session")
 def pki_prod(pytestconfig):
     return pytestconfig.getoption("pki_prod")
+
+
+@pytest.fixture(scope="session")
+def coverage_enabled(pytestconfig):
+    return pytestconfig.getoption("coverage")
 
 
 @pytest.fixture(scope="session")
@@ -414,7 +461,8 @@ def create_backend(root_pytest_dir: Path,
                    cli_user_seed: str,
                    additional_speculos_arguments: List[str],
                    verbose_speculos: bool = False,
-                   ignore_missing_binaries: bool = False) -> BackendInterface:
+                   ignore_missing_binaries: bool = False,
+                   coverage_trace_dir: Optional[Path] = None) -> BackendInterface:
     if backend_name.lower() == "ledgercomm":
         return LedgerCommBackend(device=device,
                                  interface="hid",
@@ -431,6 +479,7 @@ def create_backend(root_pytest_dir: Path,
         return SpeculosBackend(main_app_path,
                                device=device,
                                log_apdu_file=log_apdu_file,
+                               coverage_trace_dir=coverage_trace_dir,
                                **speculos_args)
     else:
         raise ValueError(f"Backend '{backend_name}' is unknown. Valid backends are: {BACKENDS}")
@@ -443,15 +492,19 @@ def create_backend(root_pytest_dir: Path,
 def backend(skip_tests_for_unsupported_devices, root_pytest_dir: Path, backend_name: str,
             device: Device, display: bool, pki_prod: bool, log_apdu_file: Optional[Path],
             cli_user_seed: str, additional_speculos_arguments: List[str], verbose_speculos: bool,
-            ignore_missing_binaries: bool) -> Generator[BackendInterface, None, None]:
+            ignore_missing_binaries: bool,
+            coverage_enabled: bool) -> Generator[BackendInterface, None, None]:
     # to separate the test name and its following logs
     print("")
+    coverage_trace_dir = None
+    if coverage_enabled:
+        coverage_trace_dir = root_pytest_dir / COVERAGE_TRACE_ROOT / device.name
     backend_instance = None
     try:
         backend_instance = create_backend(root_pytest_dir, backend_name, device, display, pki_prod,
                                           log_apdu_file, cli_user_seed,
                                           additional_speculos_arguments, verbose_speculos,
-                                          ignore_missing_binaries)
+                                          ignore_missing_binaries, coverage_trace_dir)
     except MissingElfError as e:
         pytest.fail(f"Missing ELF: {e}")
 
@@ -573,6 +626,15 @@ def pytest_configure(config):
     )
 
     _setup_log_level(config)
+
+
+def pytest_sessionstart(session):
+    # Start each coverage run from a clean trace directory so stale traces from
+    # a previous run are not mixed in.
+    if session.config.getoption("coverage"):
+        import shutil
+        trace_root = Path(session.config.rootpath).resolve() / COVERAGE_TRACE_ROOT
+        shutil.rmtree(trace_root, ignore_errors=True)
 
 
 # TODO: forward robust log level instead of boolean to Speculos

--- a/src/ragger/utils/coverage.py
+++ b/src/ragger/utils/coverage.py
@@ -1,0 +1,329 @@
+"""
+   Copyright 2022 Ledger SAS
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+# Firmware C code coverage for Speculos-based functional tests.
+#
+# The application under test is the real ARM firmware, run by Speculos through
+# `qemu-arm-static`. Unlike native unit tests (gcc `--coverage`), the firmware
+# never performs a normal libc exit, so `gcov` cannot flush counters. Instead we
+# trace at the *emulator* level:
+#
+# * QEMU honours `QEMU_LOG=in_asm` / `QEMU_LOG_FILENAME`. With `in_asm` it logs
+#   the guest assembly of every *translated* basic block. A block is translated
+#   the first time it is reached, so "translated" == "executed at least once" ==
+#   line coverage (`exec,nochain` would log every execution -- orders of
+#   magnitude bigger -- and is not needed).
+# * Ledger apps are PIC: linked high (e.g. 0xc0de0000) but loaded and executed
+#   by Speculos at a fixed base (0x40000000 for every Cortex-M target). We rebase
+#   the executed block addresses back to link addresses.
+# * We intersect those ranges with the DWARF line table of the app ELF and emit a
+#   standard lcov `.info` tracefile (uploadable to Codecov, renderable with
+#   `genhtml`).
+#
+# Limitations: line/block coverage only (no branch coverage); the app ELF must
+# keep its `.debug_*` sections (a default build does; a stripped/release build
+# does not); attribution is on the optimized build, so it is as approximate as
+# any optimized-build coverage.
+#
+# Enabling tracing requires no change to Speculos or QEMU: Speculos spawns QEMU
+# with `Popen` without an explicit `env`, so the `QEMU_LOG*` variables set in
+# `os.environ` are inherited.
+import bisect
+import fnmatch
+import os
+import re
+import shutil
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from ragger.logger import get_default_logger
+
+# Speculos maps the lowest loadable segment of the app at this fixed guest
+# virtual address for every Cortex-M target (speculos src/launcher.h:
+# `#define LOAD_ADDR ((void *)0x40000000)`).
+LOAD_BASE = 0x40000000
+
+logger = get_default_logger()
+
+# Per-session registry: device name -> (elf path, trace directory). Populated by
+# the Speculos backend when coverage is enabled, consumed at session end.
+_REGISTRY: Dict[str, Tuple[Path, Path]] = {}
+
+
+def enable(device_name: str, elf: Path, trace_dir: Path) -> None:
+    """Turn on QEMU ``in_asm`` tracing for the upcoming Speculos launches.
+
+    Sets the ``QEMU_LOG*`` environment variables (inherited by the QEMU process
+    Speculos spawns) and registers the (elf, trace_dir) couple for this device
+    so the traces can be converted at the end of the session. ``%d`` in the
+    filename is expanded by QEMU to the process pid: the backend is usually
+    class-scoped, so several QEMU instances run and each must write its own file.
+    """
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    os.environ["QEMU_LOG"] = "in_asm"
+    os.environ["QEMU_LOG_FILENAME"] = str(trace_dir / "cov-%d.log")
+    _REGISTRY[device_name] = (Path(elf), trace_dir)
+    logger.info("[coverage] tracing enabled for %s -> %s", device_name, trace_dir)
+
+
+def registered() -> Dict[str, Tuple[Path, Path]]:
+    return dict(_REGISTRY)
+
+
+def _run(cmd: List[str]) -> str:
+    return subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+
+
+def _text_range(readelf: str, elf: Path) -> Tuple[int, int]:
+    """Return (vma, size) of the .text section of the app ELF."""
+    out = _run([readelf, "-S", str(elf)])
+    for line in out.splitlines():
+        m = re.search(r"\.text\s+\w+\s+([0-9a-f]+)\s+[0-9a-f]+\s+([0-9a-f]+)", line)
+        if m:
+            return int(m.group(1), 16), int(m.group(2), 16)
+    raise ValueError(f"no .text section found in {elf}")
+
+
+def _parse_traces(trace_files: List[Path], lo: int, hi: int, delta: int) -> List[Tuple[int, int]]:
+    """Parse in_asm traces -> sorted executed link-address ranges (deduped).
+
+    ``lo``/``hi`` bound the app .text in *runtime* addresses; ``delta`` rebases a
+    runtime address to its link address.
+    """
+    ranges: Set[Tuple[int, int]] = set()
+    block_re = re.compile(r"^(0x[0-9a-f]+):")
+
+    def flush(addr: Optional[int], length: int) -> None:
+        if addr is not None and lo <= addr < hi and length:
+            ranges.add((addr + delta, addr + length + delta))
+
+    for path in trace_files:
+        cur_addr: Optional[int] = None
+        cur_len = 0
+        with open(path, errors="ignore") as fh:
+            for line in fh:
+                m = block_re.match(line)
+                if m:
+                    flush(cur_addr, cur_len)
+                    cur_addr, cur_len = int(m.group(1), 16), 0
+                elif line.startswith("OBJD-T:"):
+                    cur_len += len(line.split(":", 1)[1].strip()) // 2
+            flush(cur_addr, cur_len)
+    return sorted(ranges)
+
+
+def _line_table(readelf: str, elf: Path, vlo: int, vhi: int) -> List[Tuple[int, str, int]]:
+    """DWARF line table -> sorted (addr, source_path, line) statements in range."""
+    out = _run([readelf, "--debug-dump=decodedline", str(elf)])
+    entries: List[Tuple[int, str, int]] = []
+    cur_path: Optional[str] = None
+    hdr_re = re.compile(r"^(\S*\.(?:c|h|cpp|cc|cxx)):\s*$")
+    ent_re = re.compile(r"^\S+\s+(\d+)\s+(0x[0-9a-f]+)")
+    for line in out.splitlines():
+        h = hdr_re.match(line)
+        if h:
+            cur_path = h.group(1)
+            continue
+        m = ent_re.match(line)
+        if m and cur_path:
+            addr, lno = int(m.group(2), 16), int(m.group(1))
+            if lno and vlo <= addr < vhi:
+                entries.append((addr, cur_path, lno))
+    entries.sort()
+    return entries
+
+
+def _repo_relative(source_path: str, project_root: Path,
+                   cache: Dict[str, Optional[str]]) -> Optional[str]:
+    """Map a DWARF source path to a path relative to ``project_root``.
+
+    Generic and toolchain-agnostic: strip the longest leading prefix such that
+    the remainder exists as a file under ``project_root``. Drops anything not in
+    the repo (SDK headers under /opt, libc under /usr, ...).
+    """
+    if source_path in cache:
+        return cache[source_path]
+    parts = Path(source_path).parts
+    root = project_root.resolve()
+    result: Optional[str] = None
+    for i in range(len(parts)):
+        candidate = Path(*parts[i:])
+        # Skip absolute candidates: `root / "/opt/x"` would collapse to "/opt/x"
+        # and could match a real file *outside* the repo (e.g. SDK headers).
+        if candidate.is_absolute():
+            continue
+        full = root / candidate
+        if not full.is_file():
+            continue
+        # Guard against `..` escaping the repo.
+        try:
+            full.resolve().relative_to(root)
+        except ValueError:
+            continue
+        result = candidate.as_posix()
+        break
+    cache[source_path] = result
+    return result
+
+
+def _excluded(rel: str, patterns: List[str]) -> bool:
+    """Whether a repo-relative path matches one of the exclusion patterns.
+
+    A pattern matches if it equals the path, is a leading directory of it, or is
+    an fnmatch glob matching it. So `ethereum-plugin-sdk`, `ethereum-plugin-sdk/`
+    and `ethereum-plugin-sdk/*` all exclude the vendored submodule.
+    """
+    for pat in patterns:
+        pat = pat.strip().rstrip("/")
+        if not pat:
+            continue
+        if rel == pat or rel.startswith(pat + "/") or fnmatch.fnmatch(rel, pat):
+            return True
+    return False
+
+
+def to_lcov(elf: Path,
+            trace_files: List[Path],
+            output: Path,
+            project_root: Path,
+            readelf: str = "readelf",
+            load_base: int = LOAD_BASE,
+            exclude: Optional[List[str]] = None) -> Tuple[int, int, int]:
+    """Convert in_asm traces into an lcov tracefile.
+
+    ``exclude`` is an optional list of patterns (see :func:`_excluded`) removing
+    matching repo-relative source paths, e.g. vendored submodules.
+
+    Returns (files, covered_lines, instrumented_lines). Raises ValueError if the
+    ELF has no DWARF line info, or if no app code was executed.
+    """
+    patterns = exclude or []
+    tvma, tsize = _text_range(readelf, elf)
+    delta = tvma - load_base
+    exec_ranges = _parse_traces(trace_files, load_base, load_base + tsize, delta)
+    entries = _line_table(readelf, elf, tvma, tvma + tsize)
+
+    if not entries:
+        raise ValueError(f"no DWARF line info in {elf}; build with debug symbols "
+                         "(a default build keeps them, a stripped build does not)")
+    if not exec_ranges:
+        raise ValueError(f"no app code executed in [{load_base:#x}, "
+                         f"{load_base + tsize:#x}); check traces and load base")
+
+    starts = [r[0] for r in exec_ranges]
+    hits: Dict[str, Dict[int, int]] = defaultdict(lambda: defaultdict(int))
+    instr: Dict[str, Set[int]] = defaultdict(set)
+    path_cache: Dict[str, Optional[str]] = {}
+
+    for i, (addr, src, lno) in enumerate(entries):
+        nxt = entries[i + 1][0] if i + 1 < len(entries) else addr + 4
+        rel = _repo_relative(src, project_root, path_cache)
+        if rel is None or _excluded(rel, patterns):  # not a repo source, or excluded
+            continue
+        instr[rel].add(lno)
+        # any executed block [s, e) intersecting this statement [addr, nxt) ?
+        j = bisect.bisect_right(starts, nxt) - 1
+        while j >= 0 and exec_ranges[j][1] > addr:
+            if exec_ranges[j][0] < nxt:
+                hits[rel][lno] += 1
+                break
+            j -= 1
+
+    files = cov = total = 0
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with open(output, "w") as o:
+        for rel in sorted(instr):
+            o.write(f"SF:{rel}\n")
+            lh = 0
+            for lno in sorted(instr[rel]):
+                c = hits[rel].get(lno, 0)
+                o.write(f"DA:{lno},{c}\n")
+                lh += 1 if c else 0
+            o.write(f"LH:{lh}\nLF:{len(instr[rel])}\nend_of_record\n")
+            files += 1
+            cov += lh
+            total += len(instr[rel])
+    return files, cov, total
+
+
+def to_html(info: Path, html_dir: Path, project_root: Path) -> Optional[Path]:
+    """Render an lcov ``.info`` into an HTML report with ``genhtml``.
+
+    Run from ``project_root`` so the repo-relative ``SF:`` paths resolve to their
+    sources. Returns the report's ``index.html`` on success, or None (with a
+    warning) if ``genhtml`` is unavailable or failed.
+    """
+    if shutil.which("genhtml") is None:
+        logger.warning("[coverage] genhtml not found, skipping HTML report "
+                       "(install the 'lcov' package)")
+        return None
+    html_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        # `source`: some sources may be absent; `unmapped`: recent genhtml is
+        # strict about line-table entries it cannot map on an optimized build.
+        subprocess.run([
+            "genhtml", "--quiet", "--ignore-errors", "source,unmapped",
+            str(info), "-o",
+            str(html_dir)
+        ],
+                       cwd=project_root,
+                       check=True,
+                       capture_output=True,
+                       text=True)
+    except subprocess.CalledProcessError as exc:
+        logger.error("[coverage] genhtml failed: %s", exc)
+        return None
+    return html_dir / "index.html"
+
+
+# One per-device coverage result: device, files, covered lines, total lines,
+# lcov path, and HTML index (or None).
+Result = Tuple[str, int, int, int, Path, Optional[Path]]
+
+
+def finalize(project_root: Path,
+             output: Path,
+             readelf: str = "readelf",
+             exclude: Optional[List[str]] = None) -> List[Result]:
+    """Convert every registered device's traces into an lcov file.
+
+    For a single device, writes ``output``. For several devices, writes one file
+    per device next to ``output`` (``<stem>-<device><suffix>``). An HTML report is
+    rendered next to each ``.info`` (``<stem>_html/``) whenever ``genhtml`` is
+    available; otherwise only the lcov file is produced. ``exclude`` removes
+    matching repo-relative source paths (e.g. vendored submodules). Returns the
+    per-device results (rendering of the human-readable summary is left to the
+    caller).
+    """
+    results: List[Result] = []
+    multi = len(registered()) > 1
+    for device, (elf, trace_dir) in sorted(registered().items()):
+        traces = sorted(trace_dir.glob("cov-*.log"))
+        if not traces:
+            logger.warning("[coverage] no traces found for %s in %s", device, trace_dir)
+            continue
+        out = output
+        if multi:
+            out = output.with_name(f"{output.stem}-{device}{output.suffix}")
+        try:
+            files, cov, total = to_lcov(elf, traces, out, project_root, readelf, exclude=exclude)
+        except ValueError as exc:
+            logger.error("[coverage] %s: %s", device, exc)
+            continue
+        html = to_html(out, out.with_name(f"{out.stem}_html"), project_root)
+        results.append((device, files, cov, total, out, html))
+    return results


### PR DESCRIPTION
Add the following parameters
- "--coverage": Allows to activate the trace for lcov to generate the coverage.info output file
- "--coverage_output": Output lcov file (default: 'coverage.info')

An html report is automatically generated in `genhtml` is available (by default in the current path where tests are executed)

It displays the summary at the end of the tests, for example
```
$ pytest --device=stax test_trusted_name.py --coverage
=================== test session starts ====================
...
=================== firmware coverage ====================
  stax: 1255/7408 lines (16.9%), 135 files -> /work/apps/app-ethereum/tests/functional/coverage.info
        HTML: /work/apps/app-ethereum/tests/functional/coverage_html/index.html
```

**NOTE**: the elf file needs to contains the `.debug*` sections, so here we need to use the binary compiled with `DEBUG=1`